### PR TITLE
Pass parent window to file save dialog

### DIFF
--- a/src/text_viewer.rs
+++ b/src/text_viewer.rs
@@ -39,10 +39,10 @@ fn main() {
 
     window.add(&vbox);
 
-    open_button.connect_clicked(move |_| {
+    open_button.connect_clicked(|_| {
         // TODO move this to a impl?
         let file_chooser = gtk::FileChooserDialog::new(
-            "Open File", None, gtk::FileChooserAction::Open,
+            "Open File", Some(&window), gtk::FileChooserAction::Open,
             [("Open", gtk::ResponseType::Ok), ("Cancel", gtk::ResponseType::Cancel)]);
         if file_chooser.run() == gtk::ResponseType::Ok as i32 {
             let filename = file_chooser.get_filename().unwrap();


### PR DESCRIPTION
Requires rust-gnome/gtk#64.

Note: I haven’t been able to build this myself because Cargo doesn’t like me messing with its `.cargo/git/checkouts` directory. I *have* been able to compile the exact change in another program, though, so I’m fairly confident it should work.