### PR TITLE
Fix building with upper gtk versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,10 @@ git = "https://github.com/gtk-rs/gdk"
 git = "https://github.com/gtk-rs/gtk"
 
 [features]
+#default = ["gtk_3_18"]
 gtk_3_10 = ["gtk/v3_10"]
-gtk_3_18 = ["gtk_3_10"]
+gtk_3_16 = ["gtk_3_10", "gtk/v3_16"]
+gtk_3_18 = ["gtk_3_16"] #for CI tools
 
 [[bin]]
 name = "basic"


### PR DESCRIPTION
IMHO `gtk_3_18` feature better changed to `gtk_3_16` for consistency
Also `defaults` commented as example