### PR TITLE
Spin button signals

### DIFF
--- a/src/gtktest.rs
+++ b/src/gtktest.rs
@@ -4,6 +4,7 @@ extern crate gtk;
 extern crate gdk;
 
 use gtk::prelude::*;
+use gtk::SpinButtonUpdatePolicy;
 use gdk::enums::modifier_type;
 
 /// Expands to its argument if GTK+ 3.10 support is configured and to `()` otherwise
@@ -148,6 +149,24 @@ fn main() {
     scale.connect_format_value(|scale, value| {
         let digits = scale.get_digits() as usize;
         format!("<{:.*}>", digits, value)
+    });
+
+    spin_button.set_update_policy(SpinButtonUpdatePolicy::IfValid);
+    spin_button.connect_input(|spin_button| {
+        let text = spin_button.get_text().unwrap();
+        println!("spin_button_input: \"{}\"", text);
+        match text.parse::<f64>() {
+            Ok(value) if value >= 90. => {
+                println!("circular right");
+                Some(Ok(10.))
+            }
+            Ok(value) if value <= 10. => {
+                println!("circular left");
+                Some(Ok(90.))
+            }
+            Ok(value) => Some(Ok(value)),
+            Err(_) => Some(Err(())),
+        }
     });
 
     let entry_clone = entry.clone();


### PR DESCRIPTION
WIP.
Example using https://developer.gnome.org/gtk3/stable/GtkSpinButton.html#GtkSpinButton-input after https://github.com/gtk-rs/gtk/pull/317
Seems returning  `GTK_INPUT_ERROR` still applied `new_value` (don't changing it equals `new_value = 0.;`), then not sure that we need it.

cc @gkoz 

Edit: `GTK_INPUT_ERROR` working normal and it depends of `update_policy`.
This old code for future reference
```rust
            Ok(value) if value >= 99. => {
                println!("circular");
                *new_value = 10.;
                Err(()) //Not working
            }
```