### PR TITLE
Add basic application example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["The Gtk-rs Project Developers"]
 [dependencies.glib]
 git = "https://github.com/gtk-rs/glib"
 
+[dependencies.gio]
+git = "https://github.com/gtk-rs/gio"
+
 [dependencies.cairo-rs]
 git = "https://github.com/gtk-rs/cairo"
 
@@ -20,12 +23,16 @@ git = "https://github.com/gtk-rs/gtk"
 
 [features]
 #default = ["gtk_3_18"]
-gtk_3_10 = ["gtk/v3_10"]
+gtk_3_6  = ["gtk/v3_6"]
+gtk_3_10 = ["gtk_3_6",  "gtk/v3_10"]
 gtk_3_16 = ["gtk_3_10", "gtk/v3_16"]
 gtk_3_18 = ["gtk_3_16"] #for CI tools
 
 [[bin]]
 name = "basic"
+
+[[bin]]
+name = "basic_application"
 
 [[bin]]
 name = "builder_basics"

--- a/src/basic.glade
+++ b/src/basic.glade
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkWindow" id="window">
+    <property name="can_focus">False</property>
+    <property name="border_width">10</property>
+    <property name="title" translatable="yes">First GTK+ Program</property>
+    <property name="window_position">center</property>
+    <property name="default_width">350</property>
+    <property name="default_height">70</property>
+    <child>
+      <object class="GtkButton" id="clickme_button">
+        <property name="label" translatable="yes">Click me!</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/src/basic_application.rs
+++ b/src/basic_application.rs
@@ -1,0 +1,50 @@
+//! # Basic Application Sample
+//!
+//! This sample demonstrates how to create a GTK application with a toplevel `window`, set its title, size and position, how to add a `button` to this `window` and how to connect signals with actions.
+
+#![crate_type = "bin"]
+
+extern crate gio;
+extern crate gtk;
+
+use gtk::Builder;
+use gtk::prelude::*;
+
+const APP_ID: &'static str = "org.gtk-rs.basic_app";
+const APP_FLAGS: gio::ApplicationFlags = gio::APPLICATION_FLAGS_NONE;
+
+#[cfg(feature = "gtk_3_6")]
+fn new_app() -> Result<gtk::Application, ()> {
+    gtk::Application::new(Some(APP_ID), APP_FLAGS)
+}
+
+#[cfg(not(feature = "gtk_3_6"))]
+fn new_app() -> Result<gtk::Application, ()> {
+    gtk::Application::new(APP_ID, APP_FLAGS)
+}
+
+fn main() {
+    let app = new_app().unwrap();
+
+    app.connect_activate(|app| {
+        let glade_src = include_str!("basic.glade");
+        let builder = Builder::new();
+        builder.add_from_string(glade_src).unwrap();
+
+        let window: gtk::Window = builder.get_object("window").unwrap();
+        app.add_window(&window);
+
+        let button: gtk::Button = builder.get_object("clickme_button").unwrap();
+        button.connect_clicked(|_| {
+            println!("clicked");
+        });
+
+        window.show_all();
+    });
+
+    // use -h to see usage options
+    let args: Vec<String> = std::env::args().collect();
+    let args: Vec<&str> = args.iter().map(|x| &x[..]).collect();
+
+    app.run(args.len() as i32, args.as_slice());
+}


### PR DESCRIPTION
This is an attempt at addressing issue #79.  I'm new to rust and gtk so feedback on improvements are welcome.

The need for the new_app function is unfortunate, but all my attempts at using cfg! result in non-compiling code because the false branch of the conditional doesn't get optimized out early enough during compilation.

I probably missed something, but it's also unfortunate that the gio dependency is needed for the call to gtk::Application::new.  Is there any mechanism to access the constant through the gtk crate?