### PR TITLE
Use crates with git replacements in `pending` branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,21 @@ name = "simple_treeview"
 
 [[bin]]
 name = "menu_bar"
+
+[replace]
+"gtk:0.1.2" = { git = 'https://github.com/EPashkin/gtk' }
+"gdk:0.5.2" = { git = 'https://github.com/EPashkin/gdk' }
+"gdk-pixbuf:0.1.2" = { git = 'https://github.com/EPashkin/gdk-pixbuf' }
+"pango:0.1.2" = { git = 'https://github.com/EPashkin/pango' }
+"cairo-rs:0.1.2" = { git = 'https://github.com/EPashkin/cairo' }
+"cairo-sys-rs:0.3.3" = { git = 'https://github.com/EPashkin/cairo' }
+"gio:0.1.2" = { git = 'https://github.com/EPashkin/gio' }
+"glib:0.1.2" = { git = 'https://github.com/EPashkin/glib' }
+"atk-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"gdk-pixbuf-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"gdk-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"gio-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"glib-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"gobject-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"gtk-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"pango-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }


### PR DESCRIPTION
This seems allow use crated `Cargo.toml` in master branch (https://github.com/EPashkin/gtk/blob/master/Cargo.toml) and remove need in `crate` branch at all.

Works well with `.cargo/config/path` overrides. Ex. my local version with https://github.com/gtk-rs/gdk/pull/140 and https://github.com/gtk-rs/gtk/pull/462 rebased on my master produces only 2 equal warnings (dependency really added in gdk's PR)
```
warning: path override for crate `gdk` has altered the original list of
dependencies; the dependency on `gobject-sys` was either added or
modified to not match the previously resolved version
```
with one `warning: package replacement is not used: https://github.com/rust-lang/crates.io-index#gdk:0.5.2
` per replaced crate in `.cargo/config/path`

⚠️ WIP. Currently linked to my forks of gtk-rs as versions in masters don't upgraded

cc @GuillaumeGomez