### PR TITLE
WIP: Add drag and drop example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,20 @@ name = "gtk-rs-examples"
 version = "0.0.1"
 authors = ["The Gtk-rs Project Developers"]
 
-[dependencies]
-glib = "^0"
-gdk = "^0"
-gdk-pixbuf = "^0"
-gtk = "^0"
-cairo-rs = "^0"
+[dependencies.glib]
+git = "https://github.com/gtk-rs/glib"
+
+[dependencies.cairo-rs]
+git = "https://github.com/gtk-rs/cairo"
+
+[dependencies.gdk-pixbuf]
+git = "https://github.com/gtk-rs/gdk-pixbuf"
+
+[dependencies.gdk]
+git = "https://github.com/gtk-rs/gdk"
+
+[dependencies.gtk]
+git = "https://github.com/gtk-rs/gtk"
 
 [features]
 #default = ["gtk_3_20"]
@@ -55,21 +63,3 @@ name = "simple_treeview"
 
 [[bin]]
 name = "menu_bar"
-
-[replace]
-"gtk:0.1.2" = { git = 'https://github.com/gtk-rs/gtk' }
-"gdk:0.5.2" = { git = 'https://github.com/gtk-rs/gdk' }
-"gdk-pixbuf:0.1.2" = { git = 'https://github.com/gtk-rs/gdk-pixbuf' }
-"pango:0.1.2" = { git = 'https://github.com/gtk-rs/pango' }
-"cairo-rs:0.1.2" = { git = 'https://github.com/gtk-rs/cairo' }
-"cairo-sys-rs:0.3.3" = { git = 'https://github.com/gtk-rs/cairo' }
-"gio:0.1.2" = { git = 'https://github.com/gtk-rs/gio' }
-"glib:0.1.2" = { git = 'https://github.com/gtk-rs/glib' }
-"atk-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
-"gdk-pixbuf-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
-"gdk-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
-"gio-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
-"glib-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
-"gobject-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
-"gtk-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
-"pango-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ name = "cairotest"
 name = "cairo_threads"
 
 [[bin]]
+name = "grid"
+
+[[bin]]
 name = "gtktest"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ git = "https://github.com/gtk-rs/gdk"
 git = "https://github.com/gtk-rs/gtk"
 
 [features]
-#default = ["gtk_3_18"]
+#default = ["gtk_3_20"]
 gtk_3_10 = ["gtk/v3_10"]
 gtk_3_16 = ["gtk_3_10", "gtk/v3_16"]
-gtk_3_18 = ["gtk_3_16"] #for CI tools
+gtk_3_18 = ["gtk_3_16", "gtk/v3_18"] #for CI tools
+gtk_3_20 = ["gtk_3_18", "gtk/v3_20"] #for CI tools
 
 [[bin]]
 name = "basic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,19 +57,19 @@ name = "simple_treeview"
 name = "menu_bar"
 
 [replace]
-"gtk:0.1.2" = { git = 'https://github.com/EPashkin/gtk' }
-"gdk:0.5.2" = { git = 'https://github.com/EPashkin/gdk' }
-"gdk-pixbuf:0.1.2" = { git = 'https://github.com/EPashkin/gdk-pixbuf' }
-"pango:0.1.2" = { git = 'https://github.com/EPashkin/pango' }
-"cairo-rs:0.1.2" = { git = 'https://github.com/EPashkin/cairo' }
-"cairo-sys-rs:0.3.3" = { git = 'https://github.com/EPashkin/cairo' }
-"gio:0.1.2" = { git = 'https://github.com/EPashkin/gio' }
-"glib:0.1.2" = { git = 'https://github.com/EPashkin/glib' }
-"atk-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
-"gdk-pixbuf-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
-"gdk-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
-"gio-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
-"glib-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
-"gobject-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
-"gtk-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
-"pango-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"gtk:0.1.2" = { git = 'https://github.com/gtk-rs/gtk' }
+"gdk:0.5.2" = { git = 'https://github.com/gtk-rs/gdk' }
+"gdk-pixbuf:0.1.2" = { git = 'https://github.com/gtk-rs/gdk-pixbuf' }
+"pango:0.1.2" = { git = 'https://github.com/gtk-rs/pango' }
+"cairo-rs:0.1.2" = { git = 'https://github.com/gtk-rs/cairo' }
+"cairo-sys-rs:0.3.3" = { git = 'https://github.com/gtk-rs/cairo' }
+"gio:0.1.2" = { git = 'https://github.com/gtk-rs/gio' }
+"glib:0.1.2" = { git = 'https://github.com/gtk-rs/glib' }
+"atk-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
+"gdk-pixbuf-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
+"gdk-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
+"gio-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
+"glib-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
+"gobject-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
+"gtk-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }
+"pango-sys:0.3.3" = { git = 'https://github.com/gtk-rs/sys' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,20 +3,12 @@ name = "gtk-rs-examples"
 version = "0.0.1"
 authors = ["The Gtk-rs Project Developers"]
 
-[dependencies.glib]
-git = "https://github.com/gtk-rs/glib"
-
-[dependencies.cairo-rs]
-git = "https://github.com/gtk-rs/cairo"
-
-[dependencies.gdk-pixbuf]
-git = "https://github.com/gtk-rs/gdk-pixbuf"
-
-[dependencies.gdk]
-git = "https://github.com/gtk-rs/gdk"
-
-[dependencies.gtk]
-git = "https://github.com/gtk-rs/gtk"
+[dependencies]
+glib = "^0"
+gdk = "^0"
+gdk-pixbuf = "^0"
+gtk = "^0"
+cairo-rs = "^0"
 
 [features]
 #default = ["gtk_3_20"]
@@ -63,3 +55,21 @@ name = "simple_treeview"
 
 [[bin]]
 name = "menu_bar"
+
+[replace]
+"gtk:0.1.2" = { git = 'https://github.com/EPashkin/gtk' }
+"gdk:0.5.2" = { git = 'https://github.com/EPashkin/gdk' }
+"gdk-pixbuf:0.1.2" = { git = 'https://github.com/EPashkin/gdk-pixbuf' }
+"pango:0.1.2" = { git = 'https://github.com/EPashkin/pango' }
+"cairo-rs:0.1.2" = { git = 'https://github.com/EPashkin/cairo' }
+"cairo-sys-rs:0.3.3" = { git = 'https://github.com/EPashkin/cairo' }
+"gio:0.1.2" = { git = 'https://github.com/EPashkin/gio' }
+"glib:0.1.2" = { git = 'https://github.com/EPashkin/glib' }
+"atk-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"gdk-pixbuf-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"gdk-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"gio-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"glib-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"gobject-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"gtk-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }
+"pango-sys:0.3.3" = { git = 'https://github.com/EPashkin/rust-gnome-sys' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ name = "cairotest"
 name = "cairo_threads"
 
 [[bin]]
+name = "drag_and_drop"
+
+[[bin]]
 name = "grid"
 
 [[bin]]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,6 @@ install:
 
 build_script:
   - cargo build
-  - cargo build --features gtk_3_18
+  - cargo build --features gtk_3_20
 
 test: false

--- a/src/drag_and_drop.rs
+++ b/src/drag_and_drop.rs
@@ -1,0 +1,69 @@
+extern crate gdk;
+extern crate gtk;
+
+use gtk::prelude::*;
+
+fn main() {
+    if gtk::init().is_err() {
+        println!("Failed to initialize GTK.");
+        return;
+    }
+
+    // Configure button as drag source
+    let button = gtk::Button::new_with_label("Drag here");
+    let targets = vec![
+        gtk::TargetEntry::new("STRING", gtk::TargetFlags::empty(), 0),
+        gtk::TargetEntry::new("text/plain", gtk::TargetFlags::empty(), 0),
+    ];
+    button.drag_source_set(gdk::MODIFIER_MASK,
+                           &targets,
+                           gdk::ACTION_COPY);
+    button.connect_drag_data_get(|_, _, s, _, _| {
+        println!("drag-data-get");
+        let data = "I'm data!";
+        s.set_text(data, data.len() as i32);
+    });
+    button.connect_drag_begin(|_, c| {
+        println!("drag-begin");
+        for t in c.list_targets() {
+            println!("{}", t.name());
+        }
+    });
+    button.connect_drag_end(|_, _| {
+        println!("drag-end");
+    });
+
+    // Configure label as drag destination
+    let label = gtk::Label::new("Drop here");
+    label.drag_dest_set(gtk::DEST_DEFAULT_ALL,
+                        &targets,
+                        gdk::ACTION_COPY);
+    label.connect_drag_data_received(|w, d, _, _, s, _, t| {
+        println!("drag-data-received");
+        if s.get_length() > 0 && s.get_format() == 8 {
+            w.set_text(&s.get_text().unwrap());
+        }
+        d.drag_finish(false, false, t);
+    });
+    button.connect_drag_drop(|_, _, _, _, _| {
+        println!("drag-drop");
+        true
+    });
+
+    // Pack widgets into the window and display everything
+    let hbox = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    hbox.pack_start(&button, true, true, 0);
+    hbox.pack_start(&label, true, true, 0);
+
+    let window = gtk::Window::new(gtk::WindowType::Toplevel);
+    window.add(&hbox);
+    window.show_all();
+
+    // GTK & main window boilerplate
+    window.connect_delete_event(|_, _| {
+        gtk::main_quit();
+        Inhibit(false)
+    });
+
+    gtk::main();
+}

--- a/src/grid.glade
+++ b/src/grid.glade
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface>
+  <requires lib="gtk+" version="3.4"/>
+  <object class="GtkWindow" id="window">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Grid example</property>
+    <child>
+      <object class="GtkGrid" id="grid">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkButton" id="button1">
+            <property name="label" translatable="yes">Button 1</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="button2">
+            <property name="label" translatable="yes">Button 2</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="button3">
+            <property name="label" translatable="yes">Button 3</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="button4">
+            <property name="label" translatable="yes">Button 4</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">3</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="button5">
+            <property name="label" translatable="yes">Button 5</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
+            <property name="width">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="button6">
+            <property name="label" translatable="yes">Button 6
+Press to resize</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">3</property>
+            <property name="top_attach">1</property>
+            <property name="height">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="button7">
+            <property name="label" translatable="yes">Button 7
+Press to move</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,0 +1,71 @@
+extern crate gtk;
+
+// make moving clones into closures more convenient
+macro_rules! clone {
+    (@param _) => ( _ );
+    (@param $x:ident) => ( $x );
+    ($($n:ident),+ => move || $body:expr) => (
+        {
+            $( let $n = $n.clone(); )+
+                move || $body
+        }
+    );
+    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
+        {
+            $( let $n = $n.clone(); )+
+                move |$(clone!(@param $p),)+| $body
+        }
+    );
+}
+
+#[cfg(feature = "gtk_3_10")]
+mod example {
+    use gtk;
+    use gtk::prelude::*;
+    use gtk::{
+        Builder, Button, Grid, Window,
+    };
+
+    pub fn main() {
+        if gtk::init().is_err() {
+            println!("Failed to initialize GTK.");
+            return;
+        }
+        let glade_src = include_str!("grid.glade");
+        let builder = Builder::new_from_string(glade_src);
+
+        let window: Window = builder.get_object("window").unwrap();
+        let grid: Grid = builder.get_object("grid").unwrap();
+        let button6: Button = builder.get_object("button6").unwrap();
+        button6.connect_clicked(clone!(grid, button6 => move |_| {
+            let height = grid.get_child_height(&button6);
+            let new_height = if height == 2 { 1 } else { 2 };
+            grid.set_child_height(&button6, new_height);
+        }));
+        let button7: Button = builder.get_object("button7").unwrap();
+        button7.connect_clicked(clone!(grid, button7 => move |_| {
+            let left_attach = grid.get_child_left_attach(&button7);
+            let new_left_attach = if left_attach == 2 { 0 } else { left_attach + 1 };
+            grid.set_child_left_attach(&button7, new_left_attach);
+        }));
+
+        window.connect_delete_event(|_, _| {
+            gtk::main_quit();
+            Inhibit(false)
+        });
+
+        window.show_all();
+        gtk::main();
+    }
+}
+
+#[cfg(feature = "gtk_3_10")]
+fn main() {
+    example::main()
+}
+
+#[cfg(not(feature = "gtk_3_10"))]
+fn main() {
+    println!("This example only work with GTK 3.10 and later");
+    println!("Did you forget to build with `--features gtk_3_10`?");
+}

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -38,15 +38,15 @@ mod example {
         let grid: Grid = builder.get_object("grid").unwrap();
         let button6: Button = builder.get_object("button6").unwrap();
         button6.connect_clicked(clone!(grid, button6 => move |_| {
-            let height = grid.get_child_height(&button6);
+            let height = grid.get_cell_height(&button6);
             let new_height = if height == 2 { 1 } else { 2 };
-            grid.set_child_height(&button6, new_height);
+            grid.set_cell_height(&button6, new_height);
         }));
         let button7: Button = builder.get_object("button7").unwrap();
         button7.connect_clicked(clone!(grid, button7 => move |_| {
-            let left_attach = grid.get_child_left_attach(&button7);
+            let left_attach = grid.get_cell_left_attach(&button7);
             let new_left_attach = if left_attach == 2 { 0 } else { left_attach + 1 };
-            grid.set_child_left_attach(&button7, new_left_attach);
+            grid.set_cell_left_attach(&button7, new_left_attach);
         }));
 
         window.connect_delete_event(|_, _| {

--- a/src/gtktest.rs
+++ b/src/gtktest.rs
@@ -5,13 +5,13 @@ extern crate gdk;
 
 #[cfg(feature = "gtk_3_10")]
 mod example {
+    use gdk;
     use gtk::prelude::*;
     use gtk::{
         self, AboutDialog, AppChooserDialog, Builder, Button, Dialog, Entry, FileChooserAction,
         FileChooserDialog, FontChooserDialog, Scale, SpinButton, RecentChooserDialog, ResponseType,
         Spinner, Window
     };
-    use gdk::enums::modifier_type;
 
     // make moving clones into closures more convenient
     macro_rules! clone {
@@ -151,13 +151,13 @@ mod example {
         });
 
         window.connect_key_press_event(clone!(entry => move |_, key| {
-            let keyval = key.as_ref().keyval;
-            let keystate = key.as_ref().state;
+            let keyval = key.get_keyval();
+            let keystate = key.get_state();
 
             println!("key pressed: {} / {:?}", keyval, keystate);
             println!("text: {}", entry.get_text().unwrap());
 
-            if keystate.intersects(modifier_type::ControlMask) {
+            if keystate.intersects(gdk::CONTROL_MASK) {
                 println!("You pressed Ctrl!");
             }
 

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -24,7 +24,7 @@ impl Notebook {
         let tab = gtk::Box::new(Orientation::Horizontal, 0);
 
         button.set_relief(ReliefStyle::None);
-        ButtonExt::set_focus_on_click(&button, false);
+        button.set_focus_on_click(false);
         button.add(&close_image);
 
         tab.pack_start(&label, false, false, 0);

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -20,7 +20,7 @@ impl Notebook {
         let close_image = gtk::Image::new_from_icon_name("window-close",
                                                          IconSize::Button.into());
         let button = gtk::Button::new();
-        let label = gtk::Label::new(Some(title));
+        let label = gtk::Label::new(title);
         let tab = gtk::Box::new(Orientation::Horizontal, 0);
 
         button.set_relief(ReliefStyle::None);
@@ -66,7 +66,7 @@ fn main() {
 
     for i in 1..4 {
         let title = format!("sheet {}", i);
-        let label = gtk::Label::new(Some(&title));
+        let label = gtk::Label::new(&*title);
         notebook.create_tab(&title, label.upcast());
     }
 

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -24,7 +24,7 @@ impl Notebook {
         let tab = gtk::Box::new(Orientation::Horizontal, 0);
 
         button.set_relief(ReliefStyle::None);
-        button.set_focus_on_click(false);
+        ButtonExt::set_focus_on_click(&button, false);
         button.add(&close_image);
 
         tab.pack_start(&label, false, false, 0);


### PR DESCRIPTION
This requires the `drag_targets` branch of `gtk` and `gdk` to be used to work at all. It's also not quite correct, but I'm not certain why yet, and these examples are a good test case to make sure that the work in `gtk` and `gdk` is correct. One shows an example of dragging a widget within an app onto another widget. The other will display metadata of anything dropped onto it.