### PR TITLE
Remove redundant delete event handler.

### DIFF
--- a/src/bin/basic.rs
+++ b/src/bin/basic.rs
@@ -12,23 +12,6 @@ use gtk::prelude::*;
 
 use std::env::args;
 
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
 
 fn build_ui(application: &gtk::Application) {
     let window = gtk::ApplicationWindow::new(application);
@@ -38,15 +21,8 @@ fn build_ui(application: &gtk::Application) {
     window.set_position(gtk::WindowPosition::Center);
     window.set_default_size(350, 70);
 
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
-
     let button = gtk::Button::new_with_label("Click me!");
-
     window.add(&button);
-
     window.show_all();
 }
 

--- a/src/bin/builder_basics.rs
+++ b/src/bin/builder_basics.rs
@@ -18,24 +18,6 @@ mod example {
     use std::env::args;
 
 
-    // make moving clones into closures more convenient
-    macro_rules! clone {
-        (@param _) => ( _ );
-        (@param $x:ident) => ( $x );
-        ($($n:ident),+ => move || $body:expr) => (
-            {
-                $( let $n = $n.clone(); )+
-                move || $body
-            }
-        );
-        ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-            {
-                $( let $n = $n.clone(); )+
-                move |$(clone!(@param $p),)+| $body
-            }
-        );
-    }
-
     pub fn build_ui(application: &gtk::Application) {
         let glade_src = include_str!("builder_basics.glade");
         let builder = Builder::new_from_string(glade_src);
@@ -46,10 +28,6 @@ mod example {
                                            .expect("Couldn't get messagedialog1");
 
         window.set_application(application);
-        window.connect_delete_event(clone!(window => move |_, _| {
-            window.destroy();
-            Inhibit(false)
-        }));
 
         bigbutton.connect_clicked(move |_| {
             dialog.run();

--- a/src/bin/cairo_threads.rs
+++ b/src/bin/cairo_threads.rs
@@ -63,11 +63,6 @@ fn build_ui(application: &gtk::Application) {
     let area = DrawingArea::new();
     window.add(&area);
 
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
-
     let format = Format::Rgb24;
     let width = 200;
     let height = 200;

--- a/src/bin/cairotest.rs
+++ b/src/bin/cairotest.rs
@@ -12,24 +12,6 @@ use gtk::DrawingArea;
 use cairo::enums::{FontSlant, FontWeight};
 use cairo::Context;
 
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
-
 fn build_ui(application: &gtk::Application) {
     drawable(application, 500, 500, |_, cr| {
         cr.set_dash(&[3., 2., 1.], 1.);
@@ -129,10 +111,6 @@ where F: Fn(&DrawingArea, &Context) -> Inhibit + 'static {
 
     window.set_default_size(width, height);
 
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
     window.add(&drawing_area);
     window.show_all();
 }

--- a/src/bin/child-properties.rs
+++ b/src/bin/child-properties.rs
@@ -9,7 +9,7 @@ extern crate gtk;
 
 use gio::prelude::*;
 use gtk::{
-    ApplicationWindow, BoxExt, Button, ButtonExt, ContainerExt, GtkWindowExt, Inhibit, Label,
+    ApplicationWindow, BoxExt, Button, ButtonExt, ContainerExt, GtkWindowExt, Label,
     LabelExt, PackType, WidgetExt,
 };
 use gtk::Orientation::Vertical;
@@ -72,11 +72,6 @@ fn build_ui(application: &gtk::Application) {
 
     window.set_default_size(200, 200);
     window.add(&vbox);
-
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
 
     window.show_all();
 }

--- a/src/bin/clock.rs
+++ b/src/bin/clock.rs
@@ -12,24 +12,6 @@ use gtk::prelude::*;
 use std::env::args;
 use chrono::Local;
 
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
-
 
 fn current_time() -> String {
     return format!("{}", Local::now().format("%Y-%m-%d %H:%M:%S"));
@@ -42,11 +24,6 @@ fn build_ui(application: &gtk::Application) {
     window.set_border_width(10);
     window.set_position(gtk::WindowPosition::Center);
     window.set_default_size(260, 40);
-
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
 
     let time = current_time();
     let label = gtk::Label::new(None);

--- a/src/bin/drag_and_drop.rs
+++ b/src/bin/drag_and_drop.rs
@@ -12,23 +12,6 @@ use gtk::prelude::*;
 
 use std::env::args;
 
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
 
 fn build_ui(application: &gtk::Application) {
     // Configure button as drag source for text
@@ -59,12 +42,6 @@ fn build_ui(application: &gtk::Application) {
     window.set_default_size(200, 100);
     window.add(&hbox);
     window.show_all();
-
-    // GTK & main window boilerplate
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
 }
 
 fn main() {

--- a/src/bin/grid.rs
+++ b/src/bin/grid.rs
@@ -55,11 +55,6 @@ mod example {
             grid.set_cell_left_attach(&button7, new_left_attach);
         }));
 
-        window.connect_delete_event(clone!(window => move |_, _| {
-            window.destroy();
-            Inhibit(false)
-        }));
-
         window.show_all();
     }
 

--- a/src/bin/gtktest.rs
+++ b/src/bin/gtktest.rs
@@ -180,11 +180,6 @@ mod example {
             Inhibit(false)
         }));
 
-        window.connect_delete_event(clone!(window => move |_, _| {
-            window.destroy();
-            Inhibit(false)
-        }));
-
         window.show_all();
     }
 

--- a/src/bin/menu_bar.rs
+++ b/src/bin/menu_bar.rs
@@ -41,11 +41,6 @@ fn build_ui(application: &gtk::Application) {
     window.set_position(WindowPosition::Center);
     window.set_size_request(400, 400);
 
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
-
     let v_box = gtk::Box::new(gtk::Orientation::Vertical, 10);
 
     let menu = Menu::new();

--- a/src/bin/menu_bar_system.rs
+++ b/src/bin/menu_bar_system.rs
@@ -9,7 +9,7 @@ extern crate gtk;
 use gio::prelude::*;
 use gtk::{
     AboutDialog, AboutDialogExt, BoxExt, ContainerExt, DialogExt, GtkApplicationExt, GtkWindowExt,
-    Inhibit, LabelExt, SwitchExt, ToVariant, WidgetExt,
+    LabelExt, SwitchExt, ToVariant, WidgetExt,
 };
 
 use std::env::args;
@@ -129,11 +129,6 @@ fn build_ui(application: &gtk::Application) {
     window.set_border_width(10);
     window.set_position(gtk::WindowPosition::Center);
     window.set_default_size(350, 70);
-
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
 
     let v_box = gtk::Box::new(gtk::Orientation::Vertical, 10);
     let label = gtk::Label::new("Nothing happened yet");

--- a/src/bin/multi_windows.rs
+++ b/src/bin/multi_windows.rs
@@ -9,23 +9,6 @@ use std::collections::HashMap;
 use std::env::args;
 use std::rc::Rc;
 
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
 
 fn create_sub_window(title: &str, main_window_entry: gtk::Entry, id: usize,
                      windows: Rc<RefCell<HashMap<usize, gtk::Window>>>) {
@@ -59,11 +42,6 @@ fn create_main_window(application: &gtk::Application) -> gtk::ApplicationWindow 
     window.set_title("I'm the main window");
     window.set_default_size(400, 200);
     window.set_position(gtk::WindowPosition::Center);
-
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
 
     window.show_all();
     window

--- a/src/bin/multithreading_context.rs
+++ b/src/bin/multithreading_context.rs
@@ -11,23 +11,6 @@ use std::sync::mpsc::{channel, Receiver};
 use std::thread;
 use std::time::Duration;
 
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
 
 fn build_ui(application: &gtk::Application) {
     let window = gtk::ApplicationWindow::new(application);
@@ -36,11 +19,6 @@ fn build_ui(application: &gtk::Application) {
     window.set_border_width(10);
     window.set_position(gtk::WindowPosition::Center);
     window.set_default_size(600, 400);
-
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
 
     let text_view = gtk::TextView::new();
     let scroll = gtk::ScrolledWindow::new(None, None);

--- a/src/bin/notebook.rs
+++ b/src/bin/notebook.rs
@@ -7,23 +7,6 @@ use gtk::{IconSize, Orientation, ReliefStyle, Widget};
 
 use std::env::args;
 
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
 
 struct Notebook {
     notebook: gtk::Notebook,
@@ -74,11 +57,6 @@ fn build_ui(application: &gtk::Application) {
     window.set_title("Notebook");
     window.set_position(gtk::WindowPosition::Center);
     window.set_default_size(640, 480);
-
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
 
     let mut notebook = Notebook::new();
 

--- a/src/bin/pango_attributes.rs
+++ b/src/bin/pango_attributes.rs
@@ -11,24 +11,6 @@ use gtk::prelude::*;
 
 use std::env::args;
 
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
-
 fn build_ui(application: &gtk::Application) {
     let window = gtk::ApplicationWindow::new(application);
 
@@ -36,11 +18,6 @@ fn build_ui(application: &gtk::Application) {
     window.set_border_width(10);
     window.set_position(gtk::WindowPosition::Center);
     window.set_default_size(350, 70);
-
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
 
     let label = gtk::Label::new("Some text");
     let attr_list = pango::AttrList::new();

--- a/src/bin/simple_treeview.rs
+++ b/src/bin/simple_treeview.rs
@@ -14,24 +14,6 @@ use gtk::{
 
 use std::env::args;
 
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
-
 fn create_and_fill_model() -> ListStore {
     // Creation of a model with two rows.
     let model = ListStore::new(&[u32::static_type(), String::static_type()]);
@@ -70,11 +52,6 @@ fn build_ui(application: &gtk::Application) {
 
     window.set_title("Simple TreeView example");
     window.set_position(WindowPosition::Center);
-
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
 
     // Creating a vertical layout to place both tree view and label in the window.
     let vertical_layout = gtk::Box::new(Orientation::Vertical, 0);

--- a/src/bin/sync_widgets.rs
+++ b/src/bin/sync_widgets.rs
@@ -12,24 +12,6 @@ use gtk::prelude::*;
 
 use std::env::args;
 
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
-
 fn build_ui(application: &gtk::Application) {
     let glade_src = include_str!("sync_widgets.glade");
     let builder = Builder::new();
@@ -49,11 +31,6 @@ fn build_ui(application: &gtk::Application) {
 
     let window: gtk::ApplicationWindow = builder.get_object("window").expect("Couldn't get window");
     window.set_application(application);
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
-
     window.show_all();
 }
 

--- a/src/bin/text_viewer.rs
+++ b/src/bin/text_viewer.rs
@@ -66,11 +66,6 @@ pub fn build_ui(application: &gtk::Application) {
         file_chooser.destroy();
     }));
 
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
-
     window.show_all();
 }
 

--- a/src/bin/transparent_main_window.rs
+++ b/src/bin/transparent_main_window.rs
@@ -18,7 +18,6 @@ fn build_ui(application: &gtk::Application) {
     let window = ApplicationWindow::new(application);
     set_visual(&window, &None);
 
-    window.connect_delete_event(quit);
     window.connect_screen_changed(set_visual);
     window.connect_draw(draw);
 
@@ -61,10 +60,5 @@ fn draw(_window: &ApplicationWindow, ctx: &cairo::Context) -> Inhibit {
     ctx.set_source_rgba(1.0, 0.0, 0.0, 0.4);
     ctx.set_operator(cairo::enums::Operator::Screen);
     ctx.paint();
-    Inhibit(false)
-}
-
-fn quit(_window: &ApplicationWindow, _event: &gdk::Event) -> Inhibit {
-    _window.destroy();
     Inhibit(false)
 }

--- a/src/bin/treeview.rs
+++ b/src/bin/treeview.rs
@@ -17,24 +17,6 @@ use gtk::{
 
 use std::env::args;
 
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
-
 fn append_text_column(tree: &TreeView) {
     let column = TreeViewColumn::new();
     let cell = CellRendererText::new();
@@ -49,11 +31,6 @@ fn build_ui(application: &gtk::Application) {
 
     window.set_title("TreeView Sample");
     window.set_position(WindowPosition::Center);
-
-    window.connect_delete_event(clone!(window => move |_, _| {
-        window.destroy();
-        Inhibit(false)
-    }));
 
     // left pane
 


### PR DESCRIPTION
Commit that introduced gtk::Application also modified window delete
event handlers, replacing calls to gtk::main_quit with ones that destroy
the application window.

The new event handler is redundant as the default delete event handler
already destroys the window.