### PR TITLE
Disable spinner in glade file, to make starting it in code meaningful

### DIFF
--- a/src/bin/gtktest.glade
+++ b/src/bin/gtktest.glade
@@ -489,7 +489,7 @@ audio-volume-medium</property>
                   <object class="GtkSpinner" id="spinner">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="active">True</property>
+                    <property name="active">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>


### PR DESCRIPTION
Fix double activating found thanks to https://github.com/gtk-rs/examples/issues/162

We already have activating in code:
```rust
let spinner: Spinner = builder.get_object("spinner").expect("Couldn't get spinner");
spinner.start();
```

cc @GuillaumeGomez 