### PR TITLE
Don't require a mutable main context in the futures examples

### DIFF
--- a/src/bin/gio_futures.rs
+++ b/src/bin/gio_futures.rs
@@ -12,7 +12,7 @@ use futures_util::FutureExt;
 use futures_util::future;
 
 fn main() {
-    let mut c = glib::MainContext::default();
+    let c = glib::MainContext::default();
     let l = glib::MainLoop::new(Some(&c), false);
 
     c.push_thread_default();

--- a/src/bin/gio_futures_await.rs
+++ b/src/bin/gio_futures_await.rs
@@ -60,7 +60,7 @@ fn read_file(file: gio::File) -> Result<(), String> {
 }
 
 fn main() {
-    let mut c = glib::MainContext::default();
+    let c = glib::MainContext::default();
     let l = glib::MainLoop::new(Some(&c), false);
 
     c.push_thread_default();


### PR DESCRIPTION
Depends on https://github.com/gtk-rs/glib/pull/328