### PR TITLE
Use futures-preview crates instead of futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,9 @@ authors = ["The Gtk-rs Project Developers"]
 [dependencies]
 chrono = "0.4"
 url = "1.4"
-futures-core = { version = "0.2", optional = true }
-futures-util = { version = "0.2", optional = true }
-futures = { version = "0.2", optional = true }
-futures-macro-async = { version = "0.2", optional = true }
-futures-macro-await = { version = "0.2", optional = true }
+futures-preview = { version = "0.2", optional = true }
+futures-macro-async-preview = { version = "0.2", optional = true }
+futures-macro-await-preview = { version = "0.2", optional = true }
 
 [dependencies.glib]
 git = "https://github.com/gtk-rs/glib"
@@ -41,8 +39,8 @@ gtk_3_16 = ["gtk_3_10", "gtk/v3_16"]
 gtk_3_18 = ["gtk_3_16", "gtk/v3_18"] #for CI tools
 gtk_3_20 = ["gtk_3_18", "gtk/v3_20"] #for CI tools
 gtk_3_22 = ["gtk_3_20", "gtk/v3_22"] #for CI tools
-futures-stable = ["futures-core", "futures-util", "glib/futures", "gio/futures"]
-futures-nightly = ["futures-stable", "glib/futures-nightly", "futures", "futures/nightly", "futures-core/nightly", "futures-macro-async", "futures-macro-async/nightly", "futures-macro-await"]
+futures-stable = ["futures-preview", "glib/futures", "gio/futures"]
+futures-nightly = ["futures-stable", "glib/futures-nightly", "futures-preview/nightly", "futures-macro-async-preview", "futures-macro-async-preview/nightly", "futures-macro-await-preview"]
 
 [[bin]]
 name = "basic"
@@ -73,7 +71,7 @@ name = "drag_and_drop_textview"
 
 [[bin]]
 name = "gio_futures"
-required-features = ["futures"]
+required-features = ["futures-stable"]
 
 [[bin]]
 name = "gio_futures_await"

--- a/src/bin/gio_futures.rs
+++ b/src/bin/gio_futures.rs
@@ -1,5 +1,4 @@
-extern crate futures_core;
-extern crate futures_util;
+extern crate futures;
 
 extern crate glib;
 
@@ -8,8 +7,8 @@ use gio::prelude::*;
 
 use std::str;
 
-use futures_util::FutureExt;
-use futures_util::future;
+use futures::FutureExt;
+use futures::future;
 
 fn main() {
     let c = glib::MainContext::default();


### PR DESCRIPTION
The futures crates were janked from crates.io and renamed to
futures-preview for whatever reason.


Nightly still does not compile because `futures-core-preview` does not compile