### PR TITLE
Add accelerators to menu examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ name = "menu_bar"
 
 [[bin]]
 name = "menu_bar_system"
+required-features = ["gtk/v3_12"]
 
 [[bin]]
 name = "multi_windows"

--- a/src/bin/menu_bar.rs
+++ b/src/bin/menu_bar.rs
@@ -10,8 +10,8 @@ extern crate gtk;
 use gio::{ApplicationExt, ApplicationExtManual};
 use gtk::prelude::*;
 use gtk::{
-    AboutDialog, ApplicationWindow, CheckMenuItem, IconSize, Image, Label, Menu, MenuBar, MenuItem,
-    WindowPosition,
+    AboutDialog, AccelFlags, AccelGroup, ApplicationWindow, CheckMenuItem, IconSize, Image, Label,
+    Menu, MenuBar, MenuItem, WindowPosition,
 };
 
 use std::env::args;
@@ -49,6 +49,8 @@ fn build_ui(application: &gtk::Application) {
     let v_box = gtk::Box::new(gtk::Orientation::Vertical, 10);
 
     let menu = Menu::new();
+    let accel_group = AccelGroup::new();
+    window.add_accel_group(&accel_group);
     let menu_bar = MenuBar::new();
     let file = MenuItem::new_with_label("File");
     let about = MenuItem::new_with_label("About");
@@ -96,6 +98,12 @@ fn build_ui(application: &gtk::Application) {
     quit.connect_activate(clone!(window => move |_| {
         window.destroy();
     }));
+
+    // `Primary` is `Ctrl` on Windows and Linux, and `command` on macOS
+    // It isn't available directly through gdk::ModifierType, since it has
+    // different values on different platforms.
+    let (key, modifier) = gtk::accelerator_parse("<Primary>Q");
+    quit.add_accelerator("activate", &accel_group, key, modifier, AccelFlags::VISIBLE);
 
     let label = Label::new(Some("MenuBar example"));
 

--- a/src/bin/menu_bar_system.rs
+++ b/src/bin/menu_bar_system.rs
@@ -122,6 +122,14 @@ fn add_actions(application: &gtk::Application, switch: &gtk::Switch, label: &gtk
     application.add_action(&switch_action);
 }
 
+fn add_accelerators(application: &gtk::Application) {
+    application.set_accels_for_action("app.about", &["F1"]);
+    // `Primary` is a platform-agnostic accelerator modifier.
+    // On Windows and Linux, `Primary` maps to the `Ctrl` key,
+    // and on macOS it maps to the `command` key.
+    application.set_accels_for_action("app.quit", &["<Primary>Q"]);
+}
+
 fn build_ui(application: &gtk::Application) {
     let window = gtk::ApplicationWindow::new(application);
 
@@ -146,6 +154,8 @@ fn build_ui(application: &gtk::Application) {
     build_system_menu(application);
 
     add_actions(application, &switch, &label, &window);
+
+    add_accelerators(application);
 
     window.show_all();
 }


### PR DESCRIPTION
"Accelerator" is the term GTK uses for keyboard shortcuts such as `Ctrl+Q`. The shortcuts get displayed for items in a menu, which seems to make these two examples the best for also demonstrating accelerators.