### PR TITLE
Remove futures-nightly from travis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ git = "https://github.com/gtk-rs/sys"
 git = "https://github.com/gtk-rs/sys"
 
 [features]
-#default = ["gtk_3_22_30", "futures-nightly"]
+#default = ["gtk_3_22_30", "futures-stable"]
 gtk_3_10 = ["gtk/v3_10"]
 gtk_3_16 = ["gtk_3_10", "gtk/v3_16"]
 gtk_3_18 = ["gtk_3_16", "gtk/v3_18"] #for CI tools

--- a/build_travis.sh
+++ b/build_travis.sh
@@ -6,14 +6,14 @@ set -e
 if [ "$GTK" = latest -o "$GTK" = "3.22.30" ]; then
 	BUNDLE="gtk-3.22.30-1"
 	if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-		FEATURES=gtk_3_22_30,futures-nightly
+		FEATURES=gtk_3_22_30,futures-stable
 	else
 		FEATURES=gtk_3_22_30,futures-stable
 	fi
 elif [ "$GTK" = "3.18" ]; then
 	BUNDLE="gtk-3.18.1-2"
 	if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-		FEATURES=gtk_3_18,futures-nightly
+		FEATURES=gtk_3_18,futures-stable
 	else
 		FEATURES=gtk_3_18,futures-stable
 	fi


### PR DESCRIPTION
futures 0.2 is not maintained any longer and the nightly parts don't
build with the latest nightly toolchain anymore.