### PR TITLE
Add progress-tracker example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,11 @@ name = "overlay"
 name = "pango_attributes"
 
 [[bin]]
+name = "progress_tracker"
+path = "src/bin/progress_tracker.rs"
+required-features = ["gtk/v3_10"]
+
+[[bin]]
 name = "simple_treeview"
 
 [[bin]]

--- a/src/bin/progress_tracker.rs
+++ b/src/bin/progress_tracker.rs
@@ -1,0 +1,211 @@
+//! Track progress with a background thread and a channel.
+
+extern crate gio;
+extern crate glib;
+extern crate gtk;
+
+use gio::prelude::*;
+use gtk::prelude::*;
+
+use std::cell::Cell;
+use std::env::args;
+use std::rc::Rc;
+use std::sync::mpsc::{self, TryRecvError};
+use std::thread;
+use std::time::Duration;
+
+pub fn main() {
+    glib::set_program_name("Progress Tracker".into());
+
+    let application = gtk::Application::new(
+        "com.github.progress-tracker",
+        gio::ApplicationFlags::empty(),
+    ).expect("initialization failed");
+
+    application.connect_startup(|app| {
+        Application::new(app);
+    });
+
+    application.connect_activate(|_| {});
+    application.run(&args().collect::<Vec<_>>());
+}
+
+pub struct Application {
+    pub widgets: Rc<Widgets>,
+}
+
+impl Application {
+    pub fn new(app: &gtk::Application) -> Self {
+        let app = Application {
+            widgets: Rc::new(Widgets::new(app)),
+        };
+
+        app.connect_progress();
+
+        app
+    }
+
+    fn connect_progress(&self) {
+        let widgets = self.widgets.clone();
+        let active = Rc::new(Cell::new(false));
+        self.widgets.main_view.button.connect_clicked(move |_| {
+            let active = active.clone();
+            if active.get() {
+                return;
+            }
+
+            active.set(true);
+
+            let (tx, rx) = mpsc::channel();
+            thread::spawn(move || {
+                for v in 1..=10 {
+                    let _ = tx.send(v);
+                    thread::sleep(Duration::from_millis(500));
+                }
+            });
+
+            let widgets = widgets.clone();
+            gtk::timeout_add(16, move || match rx.try_recv() {
+                Ok(value) => {
+                    widgets
+                        .main_view
+                        .progress
+                        .set_fraction(f64::from(value) / 10.0);
+
+                    if value == 10 {
+                        widgets
+                            .view_stack
+                            .set_visible_child(&widgets.complete_view.container);
+
+                        let widgets = widgets.clone();
+                        gtk::timeout_add(1500, move || {
+                            widgets.main_view.progress.set_fraction(0.0);
+                            widgets.view_stack.set_visible_child(&widgets.main_view.container);
+                            gtk::Continue(false)
+                        });
+                    }
+
+                    gtk::Continue(true)
+                }
+                Err(TryRecvError::Empty) => gtk::Continue(true),
+                Err(TryRecvError::Disconnected) => {
+                    active.set(false);
+                    gtk::Continue(false)
+                },
+            });
+        });
+    }
+}
+
+pub struct Widgets {
+    pub window: gtk::ApplicationWindow,
+    pub header: Header,
+    pub view_stack: gtk::Stack,
+    pub main_view: MainView,
+    pub complete_view: CompleteView,
+}
+
+impl Widgets {
+    pub fn new(application: &gtk::Application) -> Self {
+        let complete_view = CompleteView::new();
+        let main_view = MainView::new();
+
+        let view_stack = gtk::Stack::new();
+        view_stack.set_border_width(6);
+        view_stack.set_vexpand(true);
+        view_stack.set_hexpand(true);
+        view_stack.add(&main_view.container);
+        view_stack.add(&complete_view.container);
+
+        let header = Header::new();
+
+        let window = gtk::ApplicationWindow::new(application);
+        window.set_icon_name("package-x-generic");
+        window.set_property_window_position(gtk::WindowPosition::Center);
+        window.set_titlebar(&header.container);
+        window.add(&view_stack);
+        window.show_all();
+        window.set_default_size(500, 250);
+        window.connect_delete_event(move |window, _| {
+            window.destroy();
+            Inhibit(false)
+        });
+
+        Widgets {
+            window,
+            header,
+            view_stack,
+            main_view,
+            complete_view,
+        }
+    }
+}
+
+pub struct Header {
+    container: gtk::HeaderBar,
+}
+
+impl Header {
+    pub fn new() -> Self {
+        let container = gtk::HeaderBar::new();
+        container.set_title("Progress Tracker");
+        container.set_show_close_button(true);
+
+        Header { container }
+    }
+}
+
+pub struct CompleteView {
+    pub container: gtk::Grid,
+}
+
+impl CompleteView {
+    pub fn new() -> Self {
+        let label = gtk::Label::new(None);
+        label.set_markup("Task complete");
+        label.set_halign(gtk::Align::Center);
+        label.set_valign(gtk::Align::Center);
+        label.set_vexpand(true);
+        label.set_hexpand(true);
+
+        let container = gtk::Grid::new();
+        container.set_vexpand(true);
+        container.set_hexpand(true);
+        container.add(&label);
+
+        CompleteView { container }
+    }
+}
+
+pub struct MainView {
+    pub container: gtk::Grid,
+    pub progress: gtk::ProgressBar,
+    pub button: gtk::Button,
+}
+
+impl MainView {
+    pub fn new() -> Self {
+        let progress = gtk::ProgressBar::new();
+        progress.set_text("Progress Bar");
+        progress.set_show_text(true);
+        progress.set_hexpand(true);
+
+        let button = gtk::Button::new();
+        button.set_label("start");
+        button.set_halign(gtk::Align::Center);
+
+        let container = gtk::Grid::new();
+        container.attach(&progress, 0, 0, 1, 1);
+        container.attach(&button, 0, 1, 1, 1);
+        container.set_row_spacing(12);
+        container.set_border_width(6);
+        container.set_vexpand(true);
+        container.set_hexpand(true);
+
+        MainView {
+            container,
+            progress,
+            button,
+        }
+    }
+}


### PR DESCRIPTION
Adds example with a progress bar that's updated over time after clicking on a button. The button spawns a thread that sends an event each second through a channel to a `gtk::idle_add` that periodically checks for values.

Adds the cascade crate since it makes constructing GTK widgets simpler.

Closes #209 