### PR TITLE
Port cairo_threads example to use the new GLib MainContext channel in…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ name = "cairo_png"
 
 [[bin]]
 name = "cairo_threads"
+required-features = ["glib/v2_36"]
 
 [[bin]]
 name = "cairotest"


### PR DESCRIPTION
…stead of polling

This ensures that the image is redrawn only if it actually changed and
more or less immediately after it has changed instead of waiting up to
100ms.

----

Needs https://github.com/gtk-rs/glib/pull/430 merged first and then the `Cargo.toml` changes have to be dropped.