### PR TITLE
Add missing extra crate

### DIFF
--- a/src/bin/cairo_threads.rs
+++ b/src/bin/cairo_threads.rs
@@ -1,6 +1,7 @@
 extern crate cairo;
 extern crate gio;
 extern crate gtk;
+extern crate glib;
 
 use std::thread;
 use std::env::args;


### PR DESCRIPTION
cc @GuillaumeGomez, @sdroege 

Error on rust 1.28.0 in https://github.com/gtk-rs/gio/pull/185
```
error[E0658]: access to extern crates through prelude is experimental (see issue #44660)
   --> src/bin/cairo_threads.rs:143:32
    |
143 |     let (ready_tx, ready_rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
    |                                ^^^^
```