### PR TITLE
Update minimum versions and add 3.24 to the travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ addons:
     packages:
     - libgtk-3-dev
 env:
-  - GTK=3.4
+  - GTK=3.14
   - GTK=3.18
   - GTK=3.22.30
+  - GTK=3.24
 script:
   - ./build_travis.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,13 @@ git = "https://github.com/gtk-rs/gdk"
 git = "https://github.com/gtk-rs/gtk"
 
 [features]
-#default = ["gtk_3_22_30", "futures-stable", "gio_2_40", "subclassing"]
-gtk_3_10 = ["gtk/v3_10"]
-gtk_3_16 = ["gtk_3_10", "gtk/v3_16"]
+#default = ["gtk_3_22_30", "futures-stable", "subclassing"]
+gtk_3_16 = ["gtk/v3_16"]
 gtk_3_18 = ["gtk_3_16", "gtk/v3_18"] #for CI tools
 gtk_3_20 = ["gtk_3_18", "gtk/v3_20"] #for CI tools
 gtk_3_22 = ["gtk_3_20", "gtk/v3_22"] #for CI tools
 gtk_3_22_30 = ["gtk_3_22", "gtk/v3_22_30"] #for CI tools
-gio_2_40 = ["gio/v2_40"]
+gtk_3_24 = ["gtk_3_22_30", "gtk/v3_24"] #for CI tools
 futures-stable = ["futures-preview", "glib/futures", "gio/futures"]
 subclassing = ["glib/subclassing"]
 
@@ -60,7 +59,6 @@ name = "cairo_png"
 
 [[bin]]
 name = "cairo_threads"
-required-features = ["glib/v2_36"]
 
 [[bin]]
 name = "cairotest"
@@ -100,7 +98,6 @@ name = "menu_bar"
 
 [[bin]]
 name = "menu_bar_system"
-required-features = ["gtk/v3_12"]
 
 [[bin]]
 name = "multi_windows"
@@ -134,4 +131,3 @@ name = "treeview"
 
 [[bin]]
 name = "status_icon"
-required-features = ["gio_2_40"]

--- a/build_travis.sh
+++ b/build_travis.sh
@@ -3,19 +3,26 @@
 set -x
 set -e
 
-if [ "$GTK" = latest -o "$GTK" = "3.22.30" ]; then
+if [ "$GTK" = latest -o "$GTK" = "3.24" ]; then
+	BUNDLE="gtk-3.24.0-1"
+	if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+		FEATURES=gtk_3_24,futures-stable,gio/v2_44,subclassing
+	else
+		FEATURES=gtk_3_24,futures-stable,gio/v2_44,subclassing
+	fi
+elif [ "$GTK" = "3.22.30" ]; then
 	BUNDLE="gtk-3.22.30-1"
 	if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-		FEATURES=gtk_3_22_30,futures-stable,gio_2_40,subclassing
+		FEATURES=gtk_3_22_30,futures-stable,gio/v2_44,subclassing
 	else
-		FEATURES=gtk_3_22_30,futures-stable,gio_2_40,subclassing
+		FEATURES=gtk_3_22_30,futures-stable,gio/v2_44,subclassing
 	fi
 elif [ "$GTK" = "3.18" ]; then
 	BUNDLE="gtk-3.18.1-2"
 	if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-		FEATURES=gtk_3_18,futures-stable,gio_2_40,subclassing
+		FEATURES=gtk_3_18,futures-stable,gio/v2_44,subclassing
 	else
-		FEATURES=gtk_3_18,futures-stable,gio_2_40,subclassing
+		FEATURES=gtk_3_18,futures-stable,gio/v2_44,subclassing
 	fi
 fi
 


### PR DESCRIPTION
@EPashkin Can you upload a 3.24 version of the GTK bundle for travis? Until that is there this will fail :)

@GuillaumeGomez Is there any reason why we don't use docker images of reasonable well up to date Linux distros for the CI?