### PR TITLE
Port to futures 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ autobins = false
 [dependencies]
 chrono = "0.4"
 url = "1.4"
-futures-preview = { version = "0.2", optional = true }
+futures-preview = { version = "0.3.0-alpha", optional = true}
 
 [dependencies.atk]
 git = "https://github.com/gtk-rs/atk"
@@ -25,27 +25,27 @@ git = "https://github.com/gtk-rs/glib"
 git = "https://github.com/gtk-rs/gio"
 
 [dependencies.cairo-rs]
-git = "https://github.com/gtk-rs/cairo"	
-features = ["png"]	
+git = "https://github.com/gtk-rs/cairo"
+features = ["png"]
 
-[dependencies.pango]	
-git = "https://github.com/gtk-rs/pango"	
+[dependencies.pango]
+git = "https://github.com/gtk-rs/pango"
 
-[dependencies.gdk-pixbuf]	
-git = "https://github.com/gtk-rs/gdk-pixbuf"	
+[dependencies.gdk-pixbuf]
+git = "https://github.com/gtk-rs/gdk-pixbuf"
 
-[dependencies.gdk]	
-git = "https://github.com/gtk-rs/gdk"	
+[dependencies.gdk]
+git = "https://github.com/gtk-rs/gdk"
 
-[dependencies.gtk]	
+[dependencies.gtk]
 git = "https://github.com/gtk-rs/gtk"
 
 [features]
-#default = ["gtk_3_22_30", "futures-stable", "subclassing"]
+#default = ["gtk_3_22_30", "futures", "subclassing"]
 gtk_3_18 = ["gtk/v3_18", "gdk-pixbuf/v2_32", "gdk/v3_18", "gio/v2_46", "glib/v2_46", "pango/v1_38"] #for CI tools
 gtk_3_22_30 = ["gtk_3_18", "gtk/v3_22_30", "gdk-pixbuf/v2_36", "gdk/v3_22", "gio/v2_56", "glib/v2_56", "pango/v1_42"] #for CI tools
 gtk_3_24 = ["gtk_3_22_30", "gtk/v3_24", "atk/v2_30", "gdk-pixbuf/v2_36_8", "gdk/v3_24", "gio/v2_58", "glib/v2_58"] #for CI tools
-futures-stable = ["futures-preview", "glib/futures", "gio/futures"]
+futures = ["futures-preview", "glib/futures", "gio/futures"]
 subclassing = ["glib/subclassing"]
 
 [[bin]]
@@ -83,11 +83,12 @@ name = "drag_and_drop_textview"
 
 [[bin]]
 name = "gio_futures"
-required-features = ["futures-stable"]
+required-features = ["futures"]
 
-#[[bin]]
-#name = "gio_futures_await"
-#required-features = ["futures-nightly"]
+[[bin]]
+name = "gio_futures_await"
+required-features = ["futures"]
+edition = "2018"
 
 [[bin]]
 name = "grid"
@@ -144,3 +145,6 @@ name = "treeview"
 
 [[bin]]
 name = "list_store"
+
+[patch.crates-io]
+futures-preview = { git = "https://github.com/rust-lang-nursery/futures-rs.git"}

--- a/build_travis.sh
+++ b/build_travis.sh
@@ -6,23 +6,23 @@ set -e
 if [ "$GTK" = latest -o "$GTK" = "3.24" ]; then
 	BUNDLE="gtk-3.24.0-1"
 	if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-		FEATURES=gtk_3_24,futures-stable,gio/v2_44,subclassing
+		FEATURES=gtk_3_24,futures,gio/v2_44,subclassing
 	else
-		FEATURES=gtk_3_24,futures-stable,gio/v2_44,subclassing
+		FEATURES=gtk_3_24,gio/v2_44,subclassing
 	fi
 elif [ "$GTK" = "3.22.30" ]; then
 	BUNDLE="gtk-3.22.30-1"
 	if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-		FEATURES=gtk_3_22_30,futures-stable,gio/v2_44,subclassing
+		FEATURES=gtk_3_22_30,futures,gio/v2_44,subclassing
 	else
-		FEATURES=gtk_3_22_30,futures-stable,gio/v2_44,subclassing
+		FEATURES=gtk_3_22_30,gio/v2_44,subclassing
 	fi
 elif [ "$GTK" = "3.18" ]; then
 	BUNDLE="gtk-3.18.1-2"
 	if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-		FEATURES=gtk_3_18,futures-stable,gio/v2_44,subclassing
+		FEATURES=gtk_3_18,futures,gio/v2_44,subclassing
 	else
-		FEATURES=gtk_3_18,futures-stable,gio/v2_44,subclassing
+		FEATURES=gtk_3_18,gio/v2_44,subclassing
 	fi
 fi
 

--- a/src/bin/gio_futures_await.rs
+++ b/src/bin/gio_futures_await.rs
@@ -1,36 +1,30 @@
-#![feature(use_extern_macros, proc_macro_non_items, generators, pin)]
-
-extern crate futures;
-use futures::prelude::*;
-use futures::prelude::await;
+#![feature(async_await, await_macro)]
 
 extern crate glib;
-
 extern crate gio;
 use gio::prelude::*;
 
 use std::str;
 
 // Throughout our chained futures, we convert all errors to strings
-// via map_err() return them directly
-#[async]
-fn read_file(file: gio::File) -> Result<(), String> {
-    // Try to open the file
-    let (_file, strm) = await!(file.read_async_future(glib::PRIORITY_DEFAULT))
-        .map_err(|(_file, err)| format!("Failed to open file: {}", err))?;
+// via map_err() return them directly.
+async fn read_file(file: gio::File) -> Result<(), String> {
+    // Try to open the file.
+    let strm = await!(file.read_async_future(glib::PRIORITY_DEFAULT))
+        .map_err(|err| format!("Failed to open file: {}", err))?;
 
     // If opening the file succeeds, we asynchronously loop and
     // read the file in up to 64 byte chunks and re-use the same
-    // vec for each read
+    // vec for each read.
     let mut buf = vec![0; 64];
     let mut idx = 0;
 
     loop {
-        let (_strm, (b, len)) = await!(strm.read_async_future(buf, glib::PRIORITY_DEFAULT))
-            .map_err(|(_strm, (_buf, err))| format!("Failed to read from stream: {}", err))?;
+        let (b, len) = await!(strm.read_async_future(buf, glib::PRIORITY_DEFAULT))
+            .map_err(|(_buf, err)| format!("Failed to read from stream: {}", err))?;
 
         // Once 0 is returned, we know that we're done with reading, otherwise
-        // loop again and read another chunk
+        // loop again and read another chunk.
         if len == 0 {
             break;
         }
@@ -42,9 +36,9 @@ fn read_file(file: gio::File) -> Result<(), String> {
         idx += 1;
     }
 
-    // asynchronously close the stream
+    // Asynchronously close the stream in the end.
     let _ = await!(strm.close_async_future(glib::PRIORITY_DEFAULT))
-        .map_err(|(_stream, err)| format!("Failed to close stream: {}", err))?;
+        .map_err(|err| format!("Failed to close stream: {}", err))?;
 
     Ok(())
 }
@@ -58,13 +52,12 @@ fn main() {
     let file = gio::File::new_for_path("Cargo.toml");
 
     let l_clone = l.clone();
-    let future = async_block! {
+    let future = async move {
         match await!(read_file(file)) {
             Ok(()) => (),
             Err(err) => eprintln!("Got error: {}", err),
         }
         l_clone.quit();
-        Ok(())
     };
 
     c.spawn_local(future);


### PR DESCRIPTION
While this requires nightly, the API is now stabilized and will become part of Rust 1.36. IMHO we should merge this now so that it can all get wider testing.

This is currently marked as WIP because it uses https://github.com/gtk-rs/glib/pull/476 and https://github.com/gtk-rs/gir/pull/753 via Cargo patching