### PR TITLE
Update for new `glib::Value::get` signature

### DIFF
--- a/src/bin/list_store.rs
+++ b/src/bin/list_store.rs
@@ -7,6 +7,7 @@ use gtk::prelude::*;
 use std::env::args;
 use std::rc::Rc;
 
+#[derive(Debug)]
 #[repr(i32)]
 enum Columns {
     Fixed = 0,
@@ -200,8 +201,15 @@ fn fixed_toggled<W: IsA<gtk::CellRendererToggle>>(
     let iter = model.get_iter(&path).unwrap();
     let mut fixed = model
         .get_value(&iter, Columns::Fixed as i32)
-        .get::<bool>()
-        .unwrap();
+        .get_some::<bool>()
+        .unwrap_or_else(|err| {
+            panic!(
+                "ListStore value for {:?} at path {}: {}",
+                Columns::Fixed,
+                path,
+                err
+            )
+        });
     fixed = !fixed;
     model.set_value(&iter, Columns::Fixed as u32, &fixed.to_value());
 }
@@ -282,8 +290,14 @@ fn spinner_timeout(model: &gtk::ListStore) -> Continue {
     let iter = model.get_iter_first().unwrap();
     let pulse = model
         .get_value(&iter, Columns::Pulse as i32)
-        .get::<u32>()
-        .unwrap()
+        .get_some::<u32>()
+        .unwrap_or_else(|err| {
+            panic!(
+                "ListStore value for {:?} at first entry: {}",
+                Columns::Pulse,
+                err
+            )
+        })
         .wrapping_add(1);
 
     model.set_value(&iter, Columns::Pulse as i32 as u32, &pulse.to_value());

--- a/src/bin/listbox_model.rs
+++ b/src/bin/listbox_model.rs
@@ -336,11 +336,15 @@ mod row_data {
 
                 match *prop {
                     subclass::Property("name", ..) => {
-                        let name = value.get();
+                        let name = value
+                            .get()
+                            .expect("type conformity checked by `Object::set_property`");
                         self.name.replace(name);
                     }
                     subclass::Property("count", ..) => {
-                        let count = value.get().expect("Got value of wrong type");
+                        let count = value
+                            .get_some()
+                            .expect("type conformity checked by `Object::set_property`");
                         self.count.replace(count);
                     }
                     _ => unimplemented!(),

--- a/src/bin/simple_treeview.rs
+++ b/src/bin/simple_treeview.rs
@@ -83,11 +83,12 @@ fn build_ui(application: &gtk::Application) {
                 model
                     .get_value(&iter, 1)
                     .get::<String>()
-                    .expect("Couldn't get string value"),
+                    .expect("Treeview selection, column 1")
+                    .expect("Treeview selection, column 1: mandatory value not found"),
                 model
                     .get_value(&iter, 0)
-                    .get::<u32>()
-                    .expect("Couldn't get u32 value")
+                    .get_some::<u32>()
+                    .expect("Treeview selection, column 0"),
             ));
         }
     });


### PR DESCRIPTION
... in consequence of gtk-rs/glib#513

For the `Result<_, _>::expect` behaviour, please see the following discussion: https://github.com/gtk-rs/gir/pull/825#pullrequestreview-272474063. TLDR: the argument for `expect` should refer to the context (or the reason why it shouldn't panic), the error will be automatically added in the panic message (using the `Debug` trait unfortunately).

For the method names, please see: https://github.com/gtk-rs/glib/pull/513#pullrequestreview-271892055 and then https://github.com/gtk-rs/glib/pull/513#issuecomment-519547950. TLDR: `get` allows writing generic code, `get_some` is the best name we could think of to `get` the actual value for a non-optional `Type` without the need to `unwrap` an `Ok` output of `get`.