### PR TITLE
Add Printing sample

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ git = "https://github.com/gtk-rs/gdk"
 [dependencies.gtk]
 git = "https://github.com/gtk-rs/gtk"
 
+[dependencies.pangocairo]
+git = "https://github.com/gtk-rs/pangocairo"
+
 [features]
 #default = ["gtk_3_22_30"]
 gtk_3_18 = ["gtk/v3_18", "gdk-pixbuf/v2_32", "gdk/v3_18", "gio/v2_46", "glib/v2_46", "pango/v1_38"] #for CI tools
@@ -153,3 +156,6 @@ name = "list_store"
 
 [[bin]]
 name = "entry_completion"
+
+[[bin]]
+name = "printing"

--- a/src/bin/printing.glade
+++ b/src/bin/printing.glade
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkApplicationWindow" id="window">
+    <property name="can_focus">False</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="title" translatable="yes">Printing</property>
+        <property name="has_subtitle">False</property>
+        <property name="show_close_button">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkEntry" id="entry1">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">Type</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="entry2">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">Here</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="buttonprint">
+            <property name="label" translatable="yes">Print</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/src/bin/printing.rs
+++ b/src/bin/printing.rs
@@ -15,6 +15,20 @@ use gtk::prelude::*;
 
 use std::env::args;
 
+// upgrade weak reference or return
+#[macro_export]
+macro_rules! upgrade_weak {
+    ($x:ident, $r:expr) => {{
+        match $x.upgrade() {
+            Some(o) => o,
+            None => return $r,
+        }
+    }};
+    ($x:ident) => {
+        upgrade_weak!($x, ())
+    };
+}
+
 fn print(window: &gtk::Window, value1: String, value2: String) {
     let print_operation = gtk::PrintOperation::new();
 
@@ -74,11 +88,12 @@ fn build_ui(application: &gtk::Application) {
         .get_object("buttonprint")
         .expect("Couldn't get buttonprint");
 
-    let window_clone = window.clone();
+    let weak_window = window.downgrade();
     button_print.connect_clicked(move |_| {
+        let window = upgrade_weak!(weak_window);
         let text1 = entry1.get_text().expect("Couldn't get text1").to_string();
         let text2 = entry2.get_text().expect("Couldn't get text2").to_string();
-        print(&window_clone, text1, text2);
+        print(&window, text1, text2);
     });
 
     window.show_all();

--- a/src/bin/printing.rs
+++ b/src/bin/printing.rs
@@ -1,0 +1,99 @@
+//! # Printing
+//!
+//! This sample reads text from two Entry fields,
+//! shows a print dialog and prints both texts one below
+//! the other.
+
+extern crate cairo;
+extern crate gio;
+extern crate gtk;
+extern crate pango;
+extern crate pangocairo;
+
+use gio::prelude::*;
+use gtk::prelude::*;
+
+use std::env::args;
+
+fn print(window: &gtk::Window, value1: String, value2: String) {
+    let print_operation = gtk::PrintOperation::new();
+
+    // Currently unused
+    // Could be used to check whether there was a success in printing
+    //let print_operation_result: gtk::PrintOperationResult;
+
+    print_operation.connect_begin_print(move |print_operation, _| {
+        // This sets the number of pages of the document.
+        // You most likely will calculate this, but for this example
+        // it's hardcoded as 1
+        print_operation.set_n_pages(1);
+    });
+
+    print_operation.connect_draw_page(move |_, print_context, _| {
+        let cairo = print_context
+            .get_cairo_context()
+            .expect("Couldn't get cairo context");
+
+        // This allows you to get the width of the page
+        // Currently unused in this example
+        //let width = print_context.get_width();
+
+        //Initi pango and set a font
+        let font_description = pango::FontDescription::from_string("sans 14");
+        let pango_layout = print_context
+            .create_pango_layout()
+            .expect("Couldn't create pango layout");
+        pango_layout.set_font_description(Option::from(&font_description));
+
+        // Draw text1
+        pango_layout.set_text(&value1);
+        cairo.move_to(10.0, 10.0);
+        pangocairo::functions::show_layout(&cairo, &pango_layout);
+
+        //Draw text2 below text1
+        pango_layout.set_text(&value2);
+        cairo.rel_move_to(0.0, 20.0);
+        pangocairo::functions::show_layout(&cairo, &pango_layout);
+    });
+
+    //Open Print dialog setting up main window as its parent
+    print_operation
+        .run(gtk::PrintOperationAction::PrintDialog, Option::from(window))
+        .expect("Couldn't print");
+}
+
+fn build_ui(application: &gtk::Application) {
+    let glade_src = include_str!("printing.glade");
+    let builder = gtk::Builder::new_from_string(glade_src);
+
+    let window: gtk::Window = builder.get_object("window").expect("Couldn't get window");
+    window.set_application(Some(application));
+    let entry1: gtk::Entry = builder.get_object("entry1").expect("Couldn't get entry1");
+    let entry2: gtk::Entry = builder.get_object("entry2").expect("Couldn't get entry2");
+    let button_print: gtk::Button = builder
+        .get_object("buttonprint")
+        .expect("Couldn't get buttonprint");
+
+    let window_clone = window.clone();
+    button_print.connect_clicked(move |_| {
+        let text1 = entry1.get_text().expect("Couldn't get text1").to_string();
+        let text2 = entry2.get_text().expect("Couldn't get text2").to_string();
+        print(&window_clone, text1, text2);
+    });
+
+    window.show_all();
+}
+
+fn main() {
+    let application = gtk::Application::new(
+        Some("com.github.gtk-rs.examples.printing"),
+        Default::default(),
+    )
+    .expect("Initialization failed...");
+
+    application.connect_activate(|app| {
+        build_ui(app);
+    });
+
+    application.run(&args().collect::<Vec<_>>());
+}


### PR DESCRIPTION
For work I was doing a small GTK app that took some input and printed it. I was doing it in Rust with gtk-rs and, sadly, I didn't find much about how to do the printing part.
After a while looking at the GTK and gtk-rs docs and with the help of some IRC users I figured out how to do it.

After managing to do it, they suggested me to make a sample to add to this repo, so here it is.

This sample has a window with a header bar and three items: 2 Entry fields and a Button. Clicking the button starts up the print dialog with the contents of the Entry fields.

I also added the pangocairo crate, which is basically only used to render the pango Paragraph with `show_layout()`.