### PR TITLE
Clone macro

### DIFF
--- a/src/bin/cairo_threads.rs
+++ b/src/bin/cairo_threads.rs
@@ -12,29 +12,12 @@ use std::time::Duration;
 
 use cairo::{Context, Format, ImageSurface};
 use gio::prelude::*;
+use glib::clone;
 use gtk::prelude::*;
 use gtk::{ApplicationWindow, DrawingArea};
 
 const WIDTH: i32 = 200;
 const HEIGHT: i32 = 200;
-
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
 
 // Our custom image type. This stores a heap allocated byte array for the pixels for each of our
 // images, can be sent safely between threads and can be temporarily converted to a Cairo image
@@ -212,17 +195,19 @@ fn build_ui(application: &gtk::Application) {
 
     // Whenever the drawing area has to be redrawn, render the latest images in the correct
     // locations
-    area.connect_draw(clone!(workspace => move |_, cr| {
-        let (ref images, ref origins, _) = *workspace;
+    area.connect_draw(
+        clone!(@weak workspace => @default-return Inhibit(false), move |_, cr| {
+            let (ref images, ref origins, _) = *workspace;
 
-        for (image, origin) in images.iter().zip(origins.iter()) {
-            image.borrow_mut().with_surface(|surface| {
-                draw_image_if_dirty(&cr, surface, *origin, (WIDTH, HEIGHT));
-            });
-        }
+            for (image, origin) in images.iter().zip(origins.iter()) {
+                image.borrow_mut().with_surface(|surface| {
+                    draw_image_if_dirty(&cr, surface, *origin, (WIDTH, HEIGHT));
+                });
+            }
 
-        Inhibit(false)
-    }));
+            Inhibit(false)
+        }),
+    );
 
     ready_rx.attach(None, move |(thread_num, image)| {
         let (ref images, ref origins, ref workers) = *workspace;

--- a/src/bin/cairo_threads.rs
+++ b/src/bin/cairo_threads.rs
@@ -171,7 +171,7 @@ fn build_ui(application: &gtk::Application) {
         let delay = Duration::from_millis((100 << thread_num) - 5);
 
         // Spawn the worker thread
-        thread::spawn(clone!(ready_tx => move || {
+        thread::spawn(clone!(@strong ready_tx => move || {
             let mut n = 0;
             for mut image in rx.iter() {
                 n = (n + 1) % 0x10000;

--- a/src/bin/child-properties.rs
+++ b/src/bin/child-properties.rs
@@ -5,33 +5,17 @@
 #![crate_type = "bin"]
 
 extern crate gio;
+extern crate glib;
 extern crate gtk;
 
 use gio::prelude::*;
+use glib::clone;
 use gtk::prelude::*;
 use gtk::Orientation::Vertical;
 use gtk::{ApplicationWindow, Button, Label, PackType};
 
 use std::env::args;
 use std::str::FromStr;
-
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
 
 fn build_ui(application: &gtk::Application) {
     let vbox = gtk::Box::new(Vertical, 0);
@@ -51,7 +35,7 @@ fn build_ui(application: &gtk::Application) {
     let minus_button = Button::new_with_label("-");
     vbox.add(&minus_button);
 
-    minus_button.connect_clicked(clone!(counter_label => move |_| {
+    minus_button.connect_clicked(clone!(@weak counter_label => move |_| {
         let nb = counter_label.get_text()
             .and_then(|s| u32::from_str(&s).ok())
             .unwrap_or(0);
@@ -59,7 +43,7 @@ fn build_ui(application: &gtk::Application) {
             counter_label.set_text(&format!("{}", nb - 1));
         }
     }));
-    plus_button.connect_clicked(clone!(counter_label => move |_| {
+    plus_button.connect_clicked(clone!(@weak counter_label => move |_| {
         let nb = counter_label.get_text()
             .and_then(|s| u32::from_str(&s).ok())
             .unwrap_or(0);

--- a/src/bin/clipboard_simple.rs
+++ b/src/bin/clipboard_simple.rs
@@ -11,24 +11,6 @@ use std::env::args;
 use gio::prelude::*;
 use gtk::prelude::*;
 
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
-
 struct Ui {
     pub button_a1: gtk::ToggleButton,
     pub button_a2: gtk::ToggleButton,
@@ -46,10 +28,10 @@ fn build_ui(application: &gtk::Application) {
 
     // Create the whole window
     window.set_title("gtk::Clipboard Simple Example");
-    window.connect_delete_event(clone!(window => move |_, _| {
+    window.connect_delete_event(|window, _| {
         window.destroy();
         Inhibit(false)
-    }));
+    });
 
     // Create the button grid
     let grid = gtk::Grid::new();

--- a/src/bin/clone_macro.rs
+++ b/src/bin/clone_macro.rs
@@ -34,7 +34,7 @@ fn main() {
     {
         let state2 = Rc::new(RefCell::new(State::new()));
 
-        application.connect_activate(clone!(@weak state, state2 => move |app| {
+        application.connect_activate(clone!(@weak state, @weak state2 => move |app| {
             state.borrow_mut().started = true;
 
             let window = ApplicationWindow::new(app);
@@ -42,7 +42,7 @@ fn main() {
             window.set_default_size(350, 70);
 
             let button = Button::new_with_label("Click me!");
-            button.connect_clicked(clone!(@weak state, state2 => move |_| {
+            button.connect_clicked(clone!(@weak state, @weak state2 => move |_| {
                 let mut state = state.borrow_mut();
                 let mut state2 = state2.borrow_mut();
                 println!("Clicked (started: {}): {} - {}!", state.started, state.count, state2.count);

--- a/src/bin/clone_macro.rs
+++ b/src/bin/clone_macro.rs
@@ -6,13 +6,8 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use gio::prelude::*;
-use gtk::{
-    Application,
-    ApplicationWindow,
-    Button,
-    prelude::*,
-};
 use glib::clone;
+use gtk::{prelude::*, Application, ApplicationWindow, Button};
 
 #[derive(Default)]
 struct State {
@@ -30,10 +25,9 @@ impl State {
 }
 
 fn main() {
-    let application = Application::new(
-        Some("com.github.gtk-rs.examples.basic"),
-        Default::default(),
-    ).expect("failed to initialize GTK application");
+    let application =
+        Application::new(Some("com.github.gtk-rs.examples.basic"), Default::default())
+            .expect("failed to initialize GTK application");
 
     let state = Rc::new(RefCell::new(State::new()));
 

--- a/src/bin/entry_completion.rs
+++ b/src/bin/entry_completion.rs
@@ -9,20 +9,10 @@ extern crate glib;
 extern crate gtk;
 
 use gio::prelude::*;
+use glib::clone;
 use gtk::prelude::*;
 
 use std::env::args;
-
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move |$($p:tt),*| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-                move |$(clone!(@param $p),)*| $body
-        }
-    );
-}
 
 struct Data {
     description: String,
@@ -108,7 +98,7 @@ fn main() {
 
     // When activated, shuts down the application
     let quit = gio::SimpleAction::new("quit", None);
-    quit.connect_activate(clone!(application => move |_action, _parameter| {
+    quit.connect_activate(clone!(@weak application => move |_action, _parameter| {
         application.quit();
     }));
     application.set_accels_for_action("app.quit", &["<Primary>Q"]);

--- a/src/bin/grid.rs
+++ b/src/bin/grid.rs
@@ -1,27 +1,15 @@
 #![cfg_attr(not(feature = "gtk_3_10"), allow(unused_variables, unused_mut))]
 
 extern crate gio;
+extern crate glib;
 extern crate gtk;
 
 use gio::prelude::*;
+use glib::clone;
 use gtk::prelude::*;
 use gtk::{ApplicationWindow, Builder, Button, Grid};
 
 use std::env::args;
-
-// upgrade weak reference or return
-#[macro_export]
-macro_rules! upgrade_weak {
-    ($x:ident, $r:expr) => {{
-        match $x.upgrade() {
-            Some(o) => o,
-            None => return $r,
-        }
-    }};
-    ($x:ident) => {
-        upgrade_weak!($x, ())
-    };
-}
 
 fn build_ui(application: &gtk::Application) {
     let glade_src = include_str!("grid.glade");
@@ -31,21 +19,17 @@ fn build_ui(application: &gtk::Application) {
     window.set_application(Some(application));
     let grid: Grid = builder.get_object("grid").expect("Couldn't get grid");
     let button6: Button = builder.get_object("button6").expect("Couldn't get button6");
-    let weak_grid = grid.downgrade();
-    button6.connect_clicked(move |button| {
-        let grid = upgrade_weak!(weak_grid);
+    button6.connect_clicked(clone!(@weak grid => move |button| {
         let height = grid.get_cell_height(button);
         let new_height = if height == 2 { 1 } else { 2 };
         grid.set_cell_height(button, new_height);
-    });
+    }));
     let button7: Button = builder.get_object("button7").expect("Couldn't get button7");
-    let weak_grid = grid.downgrade();
-    button7.connect_clicked(move |button| {
-        let grid = upgrade_weak!(weak_grid);
+    button7.connect_clicked(clone!(@weak grid => move |button| {
         let left_attach = grid.get_cell_left_attach(button);
         let new_left_attach = if left_attach == 2 { 0 } else { left_attach + 1 };
         grid.set_cell_left_attach(button, new_left_attach);
-    });
+    }));
 
     window.show_all();
 }

--- a/src/bin/listbox_model.rs
+++ b/src/bin/listbox_model.rs
@@ -47,7 +47,7 @@ fn build_ui(application: &gtk::Application) {
     // The gtk::ListBoxRow can contain any possible widgets.
     let listbox = gtk::ListBox::new();
     listbox.bind_model(Some(&model),
-        clone!(@weak window => @default-return panic!("failed to upgrade"), move |item| {
+        clone!(@weak window => @default-panic, move |item| {
             let box_ = gtk::ListBoxRow::new();
             let item = item.downcast_ref::<RowData>().expect("Row data is of wrong type");
 
@@ -77,7 +77,7 @@ fn build_ui(application: &gtk::Application) {
         // When the edit button is clicked, a new modal dialog is created for editing
         // the corresponding row
         let edit_button = gtk::Button::new_with_label("Edit");
-        edit_button.connect_clicked(clone!(@weak window, @weak *item => move |_| {
+        edit_button.connect_clicked(clone!(@weak window, @strong item => move |_| {
             let dialog = gtk::Dialog::new_with_buttons(Some("Edit Item"), Some(&window), gtk::DialogFlags::MODAL,
                 &[("Close", ResponseType::Close)]);
             dialog.set_default_response(ResponseType::Close);

--- a/src/bin/menu_bar.rs
+++ b/src/bin/menu_bar.rs
@@ -5,9 +5,11 @@
 //! /!\ This is different from the system menu bar (which are preferred) available in `gio::Menu`!
 
 extern crate gio;
+extern crate glib;
 extern crate gtk;
 
 use gio::prelude::*;
+use glib::clone;
 use gtk::prelude::*;
 use gtk::{
     AboutDialog, AccelFlags, AccelGroup, ApplicationWindow, CheckMenuItem, IconSize, Image, Label,
@@ -15,20 +17,6 @@ use gtk::{
 };
 
 use std::env::args;
-
-// upgrade weak reference or return
-#[macro_export]
-macro_rules! upgrade_weak {
-    ($x:ident, $r:expr) => {{
-        match $x.upgrade() {
-            Some(o) => o,
-            None => return $r,
-        }
-    }};
-    ($x:ident) => {
-        upgrade_weak!($x, ())
-    };
-}
 
 fn build_ui(application: &gtk::Application) {
     let window = ApplicationWindow::new(application);
@@ -86,11 +74,9 @@ fn build_ui(application: &gtk::Application) {
     other.set_submenu(Some(&other_menu));
     menu_bar.append(&other);
 
-    let window_weak = window.downgrade();
-    quit.connect_activate(move |_| {
-        let window = upgrade_weak!(window_weak);
+    quit.connect_activate(clone!(@weak window => move |_| {
         window.destroy();
-    });
+    }));
 
     // `Primary` is `Ctrl` on Windows and Linux, and `command` on macOS
     // It isn't available directly through gdk::ModifierType, since it has

--- a/src/bin/menu_bar_system.rs
+++ b/src/bin/menu_bar_system.rs
@@ -4,31 +4,15 @@
 //! over the `gtk::MenuBar` since it adapts to the targetted system.
 
 extern crate gio;
+extern crate glib;
 extern crate gtk;
 
 use gio::prelude::*;
+use glib::clone;
 use gtk::prelude::*;
 use gtk::AboutDialog;
 
 use std::env::args;
-
-// make moving clones into closures more convenient
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move || $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move || $body
-        }
-    );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
 
 fn build_system_menu(application: &gtk::Application) {
     let menu = gio::Menu::new();
@@ -67,7 +51,7 @@ fn add_actions(
 ) {
     // Thanks to this method, we can say that this item is actually a checkbox.
     let switch_action = gio::SimpleAction::new_stateful("switch", None, &false.to_variant());
-    switch_action.connect_activate(clone!(switch => move |g, _| {
+    switch_action.connect_activate(clone!(@weak *switch => move |g, _| {
         let mut is_active = false;
         if let Some(g) = g.get_state() {
             is_active = g.get().expect("couldn't get bool");
@@ -80,30 +64,30 @@ fn add_actions(
 
     // The same goes the around way: if we update the switch state, we need to update the menu
     // item's state.
-    switch.connect_property_active_notify(clone!(switch_action => move |s| {
+    switch.connect_property_active_notify(clone!(@weak *switch_action => move |s| {
         switch_action.change_state(&s.get_active().to_variant());
     }));
 
     let sub_another = gio::SimpleAction::new("sub_another", None);
-    sub_another.connect_activate(clone!(label => move |_, _| {
+    sub_another.connect_activate(clone!(@weak *label => move |_, _| {
         label.set_text("sub another menu item clicked");
     }));
     let sub_sub_another = gio::SimpleAction::new("sub_sub_another", None);
-    sub_sub_another.connect_activate(clone!(label => move |_, _| {
+    sub_sub_another.connect_activate(clone!(@weak *label => move |_, _| {
         label.set_text("sub sub another menu item clicked");
     }));
     let sub_sub_another2 = gio::SimpleAction::new("sub_sub_another2", None);
-    sub_sub_another2.connect_activate(clone!(label => move |_, _| {
+    sub_sub_another2.connect_activate(clone!(@weak *label => move |_, _| {
         label.set_text("sub sub another2 menu item clicked");
     }));
 
     let quit = gio::SimpleAction::new("quit", None);
-    quit.connect_activate(clone!(window => move |_, _| {
+    quit.connect_activate(clone!(@weak *window => move |_, _| {
         window.destroy();
     }));
 
     let about = gio::SimpleAction::new("about", None);
-    about.connect_activate(clone!(window => move |_, _| {
+    about.connect_activate(clone!(@weak *window => move |_, _| {
         let p = AboutDialog::new();
         p.set_website_label(Some("gtk-rs"));
         p.set_website(Some("http://gtk-rs.org"));

--- a/src/bin/menu_bar_system.rs
+++ b/src/bin/menu_bar_system.rs
@@ -51,7 +51,7 @@ fn add_actions(
 ) {
     // Thanks to this method, we can say that this item is actually a checkbox.
     let switch_action = gio::SimpleAction::new_stateful("switch", None, &false.to_variant());
-    switch_action.connect_activate(clone!(@weak *switch => move |g, _| {
+    switch_action.connect_activate(clone!(@weak switch => move |g, _| {
         let mut is_active = false;
         if let Some(g) = g.get_state() {
             is_active = g.get().expect("couldn't get bool");
@@ -64,30 +64,30 @@ fn add_actions(
 
     // The same goes the around way: if we update the switch state, we need to update the menu
     // item's state.
-    switch.connect_property_active_notify(clone!(@weak *switch_action => move |s| {
+    switch.connect_property_active_notify(clone!(@weak switch_action => move |s| {
         switch_action.change_state(&s.get_active().to_variant());
     }));
 
     let sub_another = gio::SimpleAction::new("sub_another", None);
-    sub_another.connect_activate(clone!(@weak *label => move |_, _| {
+    sub_another.connect_activate(clone!(@weak label => move |_, _| {
         label.set_text("sub another menu item clicked");
     }));
     let sub_sub_another = gio::SimpleAction::new("sub_sub_another", None);
-    sub_sub_another.connect_activate(clone!(@weak *label => move |_, _| {
+    sub_sub_another.connect_activate(clone!(@weak label => move |_, _| {
         label.set_text("sub sub another menu item clicked");
     }));
     let sub_sub_another2 = gio::SimpleAction::new("sub_sub_another2", None);
-    sub_sub_another2.connect_activate(clone!(@weak *label => move |_, _| {
+    sub_sub_another2.connect_activate(clone!(@weak label => move |_, _| {
         label.set_text("sub sub another2 menu item clicked");
     }));
 
     let quit = gio::SimpleAction::new("quit", None);
-    quit.connect_activate(clone!(@weak *window => move |_, _| {
+    quit.connect_activate(clone!(@weak window => move |_, _| {
         window.destroy();
     }));
 
     let about = gio::SimpleAction::new("about", None);
-    about.connect_activate(clone!(@weak *window => move |_, _| {
+    about.connect_activate(clone!(@weak window => move |_, _| {
         let p = AboutDialog::new();
         p.set_website_label(Some("gtk-rs"));
         p.set_website(Some("http://gtk-rs.org"));

--- a/src/bin/notebook.rs
+++ b/src/bin/notebook.rs
@@ -38,7 +38,8 @@ impl Notebook {
 
         let index = self.notebook.append_page(&widget, Some(&tab));
 
-        button.connect_clicked(clone!(@weak self.notebook => move |_| {
+        let notebook = &self.notebook;
+        button.connect_clicked(clone!(@weak notebook => move |_| {
             let index = notebook
                 .page_num(&widget)
                 .expect("Couldn't get page_num from notebook");

--- a/src/bin/notebook.rs
+++ b/src/bin/notebook.rs
@@ -1,25 +1,13 @@
 extern crate gio;
+extern crate glib;
 extern crate gtk;
 
 use gio::prelude::*;
+use glib::clone;
 use gtk::prelude::*;
 use gtk::{IconSize, Orientation, ReliefStyle, Widget};
 
 use std::env::args;
-
-// upgrade weak reference or return
-#[macro_export]
-macro_rules! upgrade_weak {
-    ($x:ident, $r:expr) => {{
-        match $x.upgrade() {
-            Some(o) => o,
-            None => return $r,
-        }
-    }};
-    ($x:ident) => {
-        upgrade_weak!($x, ())
-    };
-}
 
 struct Notebook {
     notebook: gtk::Notebook,
@@ -50,14 +38,12 @@ impl Notebook {
 
         let index = self.notebook.append_page(&widget, Some(&tab));
 
-        let notebook_weak = self.notebook.downgrade();
-        button.connect_clicked(move |_| {
-            let notebook = upgrade_weak!(notebook_weak);
+        button.connect_clicked(clone!(@weak self.notebook => move |_| {
             let index = notebook
                 .page_num(&widget)
                 .expect("Couldn't get page_num from notebook");
             notebook.remove_page(Some(index));
-        });
+        }));
 
         self.tabs.push(tab);
 

--- a/src/bin/printing.rs
+++ b/src/bin/printing.rs
@@ -6,28 +6,16 @@
 
 extern crate cairo;
 extern crate gio;
+extern crate glib;
 extern crate gtk;
 extern crate pango;
 extern crate pangocairo;
 
 use gio::prelude::*;
+use glib::clone;
 use gtk::prelude::*;
 
 use std::env::args;
-
-// upgrade weak reference or return
-#[macro_export]
-macro_rules! upgrade_weak {
-    ($x:ident, $r:expr) => {{
-        match $x.upgrade() {
-            Some(o) => o,
-            None => return $r,
-        }
-    }};
-    ($x:ident) => {
-        upgrade_weak!($x, ())
-    };
-}
 
 fn print(window: &gtk::Window, value1: String, value2: String) {
     let print_operation = gtk::PrintOperation::new();
@@ -88,13 +76,11 @@ fn build_ui(application: &gtk::Application) {
         .get_object("buttonprint")
         .expect("Couldn't get buttonprint");
 
-    let weak_window = window.downgrade();
-    button_print.connect_clicked(move |_| {
-        let window = upgrade_weak!(weak_window);
+    button_print.connect_clicked(clone!(@weak window => move |_| {
         let text1 = entry1.get_text().expect("Couldn't get text1").to_string();
         let text2 = entry2.get_text().expect("Couldn't get text2").to_string();
         print(&window, text1, text2);
-    });
+    }));
 
     window.show_all();
 }

--- a/src/bin/progress_tracker.rs
+++ b/src/bin/progress_tracker.rs
@@ -5,6 +5,7 @@ extern crate glib;
 extern crate gtk;
 
 use gio::prelude::*;
+use glib::clone;
 use gtk::prelude::*;
 
 use std::cell::{Cell, RefCell};
@@ -12,20 +13,6 @@ use std::env::args;
 use std::rc::Rc;
 use std::thread;
 use std::time::Duration;
-
-// upgrade weak reference or return
-#[macro_export]
-macro_rules! upgrade_weak {
-    ($x:ident, $r:expr) => {{
-        match $x.upgrade() {
-            Some(o) => o,
-            None => return $r,
-        }
-    }};
-    ($x:ident) => {
-        upgrade_weak!($x, ())
-    };
-}
 
 pub fn main() {
     glib::set_program_name(Some("Progress Tracker"));
@@ -70,10 +57,8 @@ impl Application {
     }
 
     fn connect_progress(&self) {
-        let widgets = Rc::downgrade(&self.widgets);
         let active = Rc::new(Cell::new(false));
-        self.widgets.main_view.button.connect_clicked(move |_| {
-            let widgets = upgrade_weak!(widgets);
+        self.widgets.main_view.button.connect_clicked(clone!(@weak self.widgets => move |_| {
             if active.get() {
                 return;
             }
@@ -120,7 +105,7 @@ impl Application {
                     glib::Continue(false)
                 }
             });
-        });
+        }));
     }
 }
 

--- a/src/bin/progress_tracker.rs
+++ b/src/bin/progress_tracker.rs
@@ -58,7 +58,8 @@ impl Application {
 
     fn connect_progress(&self) {
         let active = Rc::new(Cell::new(false));
-        self.widgets.main_view.button.connect_clicked(clone!(@weak self.widgets => move |_| {
+	let widgets = &self.widgets;
+        self.widgets.main_view.button.connect_clicked(clone!(@weak widgets => move |_| {
             if active.get() {
                 return;
             }

--- a/src/bin/text_viewer.rs
+++ b/src/bin/text_viewer.rs
@@ -3,6 +3,7 @@
 //! A simple text file viewer
 
 extern crate gio;
+extern crate glib;
 extern crate gtk;
 
 use std::env::args;
@@ -11,22 +12,9 @@ use std::io::prelude::*;
 use std::io::BufReader;
 
 use gio::prelude::*;
+use glib::clone;
 use gtk::prelude::*;
 use gtk::Builder;
-
-// upgrade weak reference or return
-#[macro_export]
-macro_rules! upgrade_weak {
-    ($x:ident, $r:expr) => {{
-        match $x.upgrade() {
-            Some(o) => o,
-            None => return $r,
-        }
-    }};
-    ($x:ident) => {
-        upgrade_weak!($x, ())
-    };
-}
 
 pub fn build_ui(application: &gtk::Application) {
     let glade_src = include_str!("text_viewer.glade");
@@ -44,10 +32,7 @@ pub fn build_ui(application: &gtk::Application) {
         .get_object("text_view")
         .expect("Couldn't get text_view");
 
-    let window_weak = window.downgrade();
-    open_button.connect_clicked(move |_| {
-        let window = upgrade_weak!(window_weak);
-
+    open_button.connect_clicked(clone!(@weak window => move |_| {
         // TODO move this to a impl?
         let file_chooser = gtk::FileChooserDialog::new(
             Some("Open File"),
@@ -73,7 +58,7 @@ pub fn build_ui(application: &gtk::Application) {
         }
 
         file_chooser.destroy();
-    });
+    }));
 
     window.show_all();
 }


### PR DESCRIPTION
So we currently have a few issues with the `clone` macro: since it only allows idents, it cannot take input like `x.y` or even `*x`. Updating to `expr` would be enough I guess but not sure if that will be this simple. :3

cc @EPashkin @sdroege @antoyo 