### PR TITLE
Add dependency on once_cell to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ gio = "^0"
 gdk = "^0"
 gdk-pixbuf = "^0"
 gtk = "^0"
+once_cell = "^0"
 pango = "^0"
 pangocairo = "^0"
 cairo-rs = { version = "^0", features = ["png"] }


### PR DESCRIPTION
The gtk-rs examples fail to compile because multiple examples make use of once_cell, but there is no dependency on once_cell in Cargo.toml.

```
error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
  --> src/bin/basic_subclass.rs:13:1
   |
13 | extern crate once_cell;
   | ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: for more information, see https://github.com/rust-lang/rust/issues/27812
```