### PR TITLE
Add osx test on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,28 @@ rust:
 - beta
 - 1.39.0 # stable
 - stable
-addons:
-  apt:
-    packages:
-    - libgtk-3-dev
-    - libmount-dev
 env:
   - GTK=3.14
   - GTK=3.18
   - GTK=3.22.30
   - GTK=3.24
+matrix:
+  include:
+    - os: osx
+      rust: stable
+      env: GTK=3.14
+    - os: osx
+      rust: stable
+      env: GTK=3.24
+addons:
+  apt:
+    packages:
+    - libgtk-3-dev
+    - libmount-dev
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew unlink python@2; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libffi gtk+3 cairo atk; fi
 script:
   - ./build_travis.sh
   - if [ "$TRAVIS_RUST_VERSION" == "stable" ]; then

--- a/build_travis.sh
+++ b/build_travis.sh
@@ -38,5 +38,5 @@ fi
 if [ -n "$OTHER_TARGET" ]; then
   PKG_CONFIG_ALLOW_CROSS=1 cargo check $OTHER_TARGET --features "$FEATURES" --jobs 1 "$@"
 else
-  cargo build --features "$FEATURES" --jobs 1 "$@"
+  RUSTFLAGS="-C link-dead-code" cargo build --features "$FEATURES" --jobs 1 "$@"
 fi

--- a/build_travis.sh
+++ b/build_travis.sh
@@ -35,4 +35,8 @@ if [ -n "$BUNDLE" ] && [ "$TRAVIS_OS_NAME" != "osx" ]; then
 	export PKG_CONFIG_PATH="$HOME/local/lib/pkgconfig"
 fi
 
-PKG_CONFIG_ALLOW_CROSS=1 cargo check $OTHER_TARGET --features "$FEATURES" --jobs 1 "$@"
+if [ -n "$OTHER_TARGET" ]; then
+  PKG_CONFIG_ALLOW_CROSS=1 cargo check $OTHER_TARGET --features "$FEATURES" --jobs 1 "$@"
+else
+  cargo build --features "$FEATURES" --jobs 1 "$@"
+fi

--- a/build_travis.sh
+++ b/build_travis.sh
@@ -26,7 +26,7 @@ elif [ "$GTK" = "3.18" ]; then
 	fi
 fi
 
-if [ -n "$BUNDLE" ]; then
+if [ -n "$BUNDLE" ] && [ "$TRAVIS_OS_NAME" != "osx" ]; then
 	WD="$PWD"
 	cd "$HOME"
 	curl -LO "https://github.com/EPashkin/gtk-bootstrap/releases/download/$BUNDLE/deps.txz"


### PR DESCRIPTION
@GuillaumeGomez, @sdroege I added 2 tests for OSX
and changed `cargo check` to `cargo build` in usual cases to detect link errors.

Note that travis just add it to usual 4x4 tests

We have https://github.com/gtk-rs/gtk/issues/935#issuecomment-578448919 and 
https://github.com/gtk-rs/gio/issues/272 that shows that no gio::DesktopAppInfo, gtk::Plug and gtk::Socket on macos.
First will be fixed in https://github.com/gtk-rs/gio/pull/273 (or I re-add it tomorrow).
Gtk will be fixed in https://github.com/gtk-rs/gtk/pull/944.