### PR TITLE
Prevent osx build failure

### DIFF
--- a/build_travis.sh
+++ b/build_travis.sh
@@ -38,5 +38,5 @@ fi
 if [ -n "$OTHER_TARGET" ]; then
   PKG_CONFIG_ALLOW_CROSS=1 cargo check $OTHER_TARGET --features "$FEATURES" --jobs 1 "$@"
 else
-  RUSTFLAGS="-C link-dead-code" travis_wait cargo build --features "$FEATURES" --jobs 1 "$@"
+  RUSTFLAGS="-C link-dead-code" cargo build -v --features "$FEATURES" --jobs 1 "$@"
 fi


### PR DESCRIPTION
See https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

cc @GuillaumeGomez, @sdroege 