### PR TITLE
Separate builds

### DIFF
--- a/build_travis.sh
+++ b/build_travis.sh
@@ -38,5 +38,7 @@ fi
 if [ -n "$OTHER_TARGET" ]; then
   PKG_CONFIG_ALLOW_CROSS=1 cargo check $OTHER_TARGET --features "$FEATURES" --jobs 1 "$@"
 else
-  RUSTFLAGS="-C link-dead-code" cargo build -v --features "$FEATURES" --jobs 1 "$@"
+  RUSTFLAGS="-C link-dead-code" cargo build --features "$FEATURES" --jobs 1 --bin basic "$@"
+  touch src/bin/basic.rs
+  cargo build -v --features "$FEATURES" --jobs 1 "$@"
 fi


### PR DESCRIPTION
Attempt to make link check to only one binary and build rest in normal way.

Maybe second pass will not rebuild all crates.

cc @GuillaumeGomez, @sdroege 