### PR TITLE
Fix clone_macro example

### DIFF
--- a/src/bin/clone_macro.rs
+++ b/src/bin/clone_macro.rs
@@ -34,7 +34,7 @@ fn main() {
     {
         let state2 = Rc::new(RefCell::new(State::new()));
 
-        application.connect_activate(clone!(@weak state, @weak state2 => move |app| {
+        application.connect_activate(clone!(@weak state, @strong state2 => move |app| {
             state.borrow_mut().started = true;
 
             let window = ApplicationWindow::new(app);


### PR DESCRIPTION
I'll then backport this on the pending branch. Fixes #293.

Full explanations: the `state2` variable needs to be cloned otherwise it won't exist anymore, which will prevent the closure to be actually "called" (it'll return early).

cc @sdroege @EPashkin 