### PR TITLE
Add example for GLArea

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ autobins = false
 chrono = "0.4"
 futures = "0.3"
 once_cell = "1.2.0"
+glium = { version = "0.26.0", optional = true }
+shared_library = { version = "0.1.9", optional = true }
+epoxy = { version = "0.1.0", optional = true }
 
 [dependencies.atk]
 git = "https://github.com/gtk-rs/atk"
@@ -52,6 +55,7 @@ optional = true
 gtk_3_18 = ["gtk/v3_18", "gdk-pixbuf/v2_32", "gdk/v3_18", "gio/v2_46", "glib/v2_46", "pango/v1_38"] #for CI tools
 gtk_3_22_30 = ["gtk_3_18", "gtk/v3_22_30", "gdk-pixbuf/v2_36", "gdk/v3_22", "gio/v2_56", "glib/v2_56", "pango/v1_42"] #for CI tools
 gtk_3_24 = ["gtk_3_22_30", "gtk/v3_24", "atk/v2_30", "gdk-pixbuf/v2_36_8", "gdk/v3_24", "gio/v2_58", "glib/v2_58"] #for CI tools
+glarea = ["gtk/v3_16", "glium", "shared_library", "epoxy"]
 
 [[bin]]
 name = "accessibility"
@@ -181,3 +185,7 @@ name = "printing"
 name = "gio_async_tls"
 required-features = ["async-tls"]
 edition = "2018"
+
+[[bin]]
+name = "glarea"
+required-features = ["glarea"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ version = "0.6"
 optional = true
 
 [features]
-#default = ["gtk_3_22_30"]
+#default = ["gtk_3_22_30", "glarea"]
 gtk_3_18 = ["gtk/v3_18", "gdk-pixbuf/v2_32", "gdk/v3_18", "gio/v2_46", "glib/v2_46", "pango/v1_38"] #for CI tools
 gtk_3_22_30 = ["gtk_3_18", "gtk/v3_22_30", "gdk-pixbuf/v2_36", "gdk/v3_22", "gio/v2_56", "glib/v2_56", "pango/v1_42"] #for CI tools
 gtk_3_24 = ["gtk_3_22_30", "gtk/v3_24", "atk/v2_30", "gdk-pixbuf/v2_36_8", "gdk/v3_24", "gio/v2_58", "glib/v2_58"] #for CI tools

--- a/src/bin/glarea/glium_backend.rs
+++ b/src/bin/glarea/glium_backend.rs
@@ -81,7 +81,14 @@ where
                 self.check_current_context,
                 Default::default(),
             )
-            .unwrap() // TODO: Better error handling`
+        };
+
+        let context = match context {
+            Ok(ctx) => ctx,
+            Err(err) => {
+                eprintln!("Error: unable to create glium Context: {}", err);
+                return;
+            }
         };
 
         let facade = Facade { context };

--- a/src/bin/glarea/glium_backend.rs
+++ b/src/bin/glarea/glium_backend.rs
@@ -1,6 +1,6 @@
 //! # glium_backend utility module
 //!
-//! This module provides some general utility typoes that allow glium to manage
+//! This module provides some general utility types that allow glium to manage
 //! the rendering of a GLArea.
 
 use std::cell::RefCell;

--- a/src/bin/glarea/glium_backend.rs
+++ b/src/bin/glarea/glium_backend.rs
@@ -40,17 +40,16 @@ where
 {
     let hook = GlAreaGliumHook::new(renderer, check_current_context);
 
-    gl_area.connect_realize(glib::clone!(@strong hook => move |gl_area| {
+    gl_area.connect_realize(glib::clone!(@weak hook => move |gl_area| {
         hook.borrow_mut().realize(gl_area);
     }));
 
-    gl_area.connect_unrealize(glib::clone!(@strong hook => move |gl_area| {
+    gl_area.connect_unrealize(glib::clone!(@weak hook => move |gl_area| {
         hook.borrow_mut().unrealize(gl_area);
     }));
 
-    gl_area.connect_render(glib::clone!(@strong hook => move |gl_area, gl_context| {
-        hook.borrow_mut().render(gl_area, gl_context)
-    }));
+    gl_area
+        .connect_render(move |gl_area, gl_context| hook.borrow_mut().render(gl_area, gl_context));
 }
 
 /// This struct is used to hook a GLArea widget to glium using a GliumRenderer

--- a/src/bin/glarea/glium_backend.rs
+++ b/src/bin/glarea/glium_backend.rs
@@ -1,0 +1,170 @@
+//! # glium_backend utility module
+//!
+//! This module provides some general utility typoes that allow glium to manage
+//! the rendering of a GLArea.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use gtk::{GLAreaExt, WidgetExt};
+use shared_library::dynamic_library::DynamicLibrary;
+
+/// The primary trait of this module, implemented by users to facilitate
+/// glium rendering for their GLArea
+pub trait GliumRenderer {
+    /// Use this method to set up your GL resources. This is called during the
+    /// `realize` signal callback for the GLArea. At this point, a valid
+    /// OpenGL context for the GLArea has been set up and is available via
+    /// `Facade`.
+    fn initialize(&mut self, facade: &Facade, gl_area: &gtk::GLArea);
+
+    /// Use this method to tear down your GL resources. This is called during
+    /// the `unrealize` signal callback for the GLArea.
+    fn tear_down(&mut self, gl_area: &gtk::GLArea);
+
+    /// Use this method to draw to the given Frame. This is called during the
+    /// `render` signal callback for the GLArea.
+    fn draw(
+        &mut self,
+        frame: glium::Frame,
+        gl_area: &gtk::GLArea,
+        gl_context: &gdk::GLContext,
+    ) -> gtk::Inhibit;
+}
+
+/// Utility function showing how to use a GlAreaGliumHook to connect a GLArea to
+/// glium via a GliumRenderer.
+pub fn hook_to_renderer<R>(renderer: R, gl_area: &gtk::GLArea, check_current_context: bool)
+where
+    R: GliumRenderer + 'static,
+{
+    let hook = GlAreaGliumHook::new(renderer, check_current_context);
+
+    gl_area.connect_realize(glib::clone!(@strong hook => move |gl_area| {
+        hook.borrow_mut().realize(gl_area);
+    }));
+
+    gl_area.connect_unrealize(glib::clone!(@strong hook => move |gl_area| {
+        hook.borrow_mut().unrealize(gl_area);
+    }));
+
+    gl_area.connect_render(glib::clone!(@strong hook => move |gl_area, gl_context| {
+        hook.borrow_mut().render(gl_area, gl_context)
+    }));
+}
+
+/// This struct is used to hook a GLArea widget to glium using a GliumRenderer
+pub struct GlAreaGliumHook<R>
+where
+    R: GliumRenderer,
+{
+    renderer: R,
+    facade: Option<Facade>,
+    check_current_context: bool,
+}
+
+impl<R> GlAreaGliumHook<R>
+where
+    R: GliumRenderer,
+{
+    pub fn new(renderer: R, check_current_context: bool) -> Rc<RefCell<Self>> {
+        Rc::new(RefCell::new(Self {
+            renderer,
+            facade: None,
+            check_current_context,
+        }))
+    }
+
+    pub fn realize(&mut self, gl_area: &gtk::GLArea) {
+        let context = unsafe {
+            glium::backend::Context::new::<_>(
+                Backend::new(gl_area.clone()),
+                self.check_current_context,
+                Default::default(),
+            )
+            .unwrap() // TODO: Better error handling`
+        };
+
+        let facade = Facade { context };
+        self.renderer.initialize(&facade, gl_area);
+        self.facade = Some(facade);
+    }
+
+    pub fn unrealize(&mut self, gl_area: &gtk::GLArea) {
+        self.renderer.tear_down(gl_area);
+        self.facade = None;
+    }
+
+    pub fn render(&mut self, gl_area: &gtk::GLArea, gl_context: &gdk::GLContext) -> gtk::Inhibit {
+        match &self.facade {
+            Some(facade) => {
+                let frame = glium::Frame::new(
+                    facade.context.clone(),
+                    facade.context.get_framebuffer_dimensions(),
+                );
+                self.renderer.draw(frame, gl_area, gl_context)
+            }
+            None => Default::default(),
+        }
+    }
+}
+
+pub struct Facade {
+    context: Rc<glium::backend::Context>,
+}
+
+impl glium::backend::Facade for Facade {
+    fn get_context(&self) -> &Rc<glium::backend::Context> {
+        &self.context
+    }
+}
+
+struct Backend {
+    gl_area: gtk::GLArea,
+}
+
+impl Backend {
+    pub fn new(gl_area: gtk::GLArea) -> Self {
+        Self { gl_area }
+    }
+}
+
+unsafe impl glium::backend::Backend for Backend {
+    fn swap_buffers(&self) -> Result<(), glium::SwapBuffersError> {
+        Ok(())
+    }
+
+    unsafe fn get_proc_address(&self, symbol: &str) -> *const std::os::raw::c_void {
+        // Strictly speaking, this call should only be needed once, but putting
+        // it here ensures the correct behaviour even if it is a bit slow at
+        // startup.
+        epoxy::load_with(
+            |symbol| match DynamicLibrary::open(None).unwrap().symbol(symbol) {
+                Ok(pointer) => pointer,
+                Err(_) => std::ptr::null(),
+            },
+        );
+        epoxy::get_proc_addr(symbol)
+    }
+
+    fn get_framebuffer_dimensions(&self) -> (u32, u32) {
+        (
+            self.gl_area.get_allocated_width() as u32,
+            self.gl_area.get_allocated_height() as u32,
+        )
+    }
+
+    fn is_current(&self) -> bool {
+        match self.gl_area.get_context() {
+            None => false,
+            Some(context) => match gdk::GLContext::get_current() {
+                None => false,
+                Some(current_context) => context == current_context,
+            },
+        }
+    }
+
+    unsafe fn make_current(&self) {
+        self.gl_area.make_current();
+    }
+}

--- a/src/bin/glarea/main.rs
+++ b/src/bin/glarea/main.rs
@@ -1,0 +1,145 @@
+//! # GLArea Sample
+//!
+//! This sample demonstrates how to use the GLArea widget with glium to
+//! manage the rendering.
+
+extern crate gio;
+extern crate glib;
+extern crate glium;
+extern crate gtk;
+extern crate shared_library;
+
+use gio::prelude::*;
+use glium::Surface;
+use gtk::prelude::*;
+use gtk::WidgetExt;
+
+mod glium_backend;
+
+#[derive(Copy, Clone)]
+struct Vertex {
+    position: [f32; 2],
+    color: [f32; 3],
+}
+
+glium::implement_vertex!(Vertex, position, color);
+
+struct TriangleData {
+    vertex_buffer: glium::VertexBuffer<Vertex>,
+    indices: glium::index::NoIndices,
+    program: glium::program::Program,
+}
+
+struct Renderer {
+    triangle: Option<TriangleData>,
+}
+
+impl glium_backend::GliumRenderer for Renderer {
+    fn initialize(&mut self, facade: &glium_backend::Facade, _gl_area: &gtk::GLArea) {
+        let vertices = vec![
+            Vertex {
+                position: [0.0, 0.5],
+                color: [1.0, 0.0, 0.0],
+            },
+            Vertex {
+                position: [0.5, -0.5],
+                color: [0.0, 1.0, 0.0],
+            },
+            Vertex {
+                position: [-0.5, -0.5],
+                color: [0.0, 0.0, 1.0],
+            },
+        ];
+
+        let vertex_buffer = glium::VertexBuffer::new(facade, &vertices).unwrap();
+        let indices = glium::index::NoIndices(glium::index::PrimitiveType::TrianglesList);
+
+        let vert_shader_src = r#"
+        #version 140
+
+        in vec2 position;
+        in vec3 color;
+
+        out vec3 vertex_color;
+
+        void main() {
+            vertex_color = color;
+            gl_Position = vec4(position, 0.0, 1.0);
+        }"#;
+
+        let frag_shader_src = r#"
+        #version 140
+
+        in vec3 vertex_color;
+
+        out vec4 color;
+
+        void main() {
+            color = vec4(vertex_color, 1.0);
+        }"#;
+
+        let program =
+            glium::Program::from_source(facade, vert_shader_src, frag_shader_src, None).unwrap();
+
+        self.triangle = Some(TriangleData {
+            vertex_buffer,
+            indices,
+            program,
+        });
+    }
+
+    fn tear_down(&mut self, _gl_area: &gtk::GLArea) {
+        self.triangle = None;
+    }
+
+    fn draw(
+        &mut self,
+        mut frame: glium::Frame,
+        _gl_area: &gtk::GLArea,
+        _gl_context: &gdk::GLContext,
+    ) -> gtk::Inhibit {
+        if let Some(triangle) = &self.triangle {
+            frame.clear_color(0.3, 0.3, 0.3, 1.0);
+            frame
+                .draw(
+                    &triangle.vertex_buffer,
+                    &triangle.indices,
+                    &triangle.program,
+                    &glium::uniforms::EmptyUniforms,
+                    &Default::default(),
+                )
+                .unwrap();
+            frame.finish().unwrap();
+        }
+        Inhibit(false)
+    }
+}
+
+fn build_ui(application: &gtk::Application) {
+    let window = gtk::ApplicationWindow::new(application);
+
+    window.set_title("GLArea example");
+    window.set_size_request(400, 400);
+
+    let gl_area = gtk::GLArea::new();
+
+    let renderer = Renderer { triangle: None };
+    glium_backend::hook_to_renderer(renderer, &gl_area, false);
+
+    window.add(&gl_area);
+    window.show_all();
+}
+
+fn main() {
+    let application = gtk::Application::new(
+        Some("com.github.gtk-rs.examples.glarea"),
+        Default::default(),
+    )
+    .expect("Initialization failed...");
+
+    application.connect_activate(|app| {
+        build_ui(app);
+    });
+
+    application.run(&std::env::args().collect::<Vec<_>>());
+}


### PR DESCRIPTION
This example uses a custom glium backend to allow glium to render to a GLArea widget. A somewhat-reusable `glium_backend` module is provided to handle the messier parts of this process.

This is based on #44, but somewhat refactored for more reusability, and developed/tested with up-to-date dependencies.