### PR TITLE
Fix entry_completion quit shortcut

### DIFF
--- a/src/bin/entry_completion.rs
+++ b/src/bin/entry_completion.rs
@@ -101,7 +101,9 @@ fn main() {
     quit.connect_activate(clone!(@weak application => move |_action, _parameter| {
         application.quit();
     }));
-    application.set_accels_for_action("app.quit", &["<Primary>Q"]);
+    application.connect_startup(|application| {
+        application.set_accels_for_action("app.quit", &["<Primary>Q"]);
+    });
     application.add_action(&quit);
 
     // Run the application


### PR DESCRIPTION
Without, running `cargo run --all-features --bin entry_completion` results in this warning when starting the application and the Ctrl+Q shortcut won't work:

```
(process:1424835): Gdk-CRITICAL **: 01:44:23.486: gdk_keymap_get_for_display: assertion 'GDK_IS_DISPLAY (display)' failed

(process:1424835): Gdk-CRITICAL **: 01:44:23.488: gdk_keymap_get_modifier_mask: assertion 'GDK_IS_KEYMAP (keymap)' failed

(process:1424835): Gdk-CRITICAL **: 01:44:23.488: gdk_keymap_get_for_display: assertion 'GDK_IS_DISPLAY (display)' failed

(process:1424835): Gtk-CRITICAL **: 01:44:23.488: _gtk_replace_virtual_modifiers: assertion 'GDK_IS_KEYMAP (keymap)' failed
```

Now, it does (again).